### PR TITLE
perf(broker): optimize hot paths and lock contention (Phase 1)

### DIFF
--- a/danube-broker/src/broker_server/producer_handler.rs
+++ b/danube-broker/src/broker_server/producer_handler.rs
@@ -127,16 +127,9 @@ impl ProducerService for DanubeServerImpl {
         &self,
         request: Request<ProtoStreamMessage>,
     ) -> Result<Response<MessageResponse>, tonic::Status> {
-        let security_context = get_security_context(&request)?;
+        let _security_context = get_security_context(&request)?;
         let req = request.into_inner();
         let stream_message: StreamMessage = req.into();
-
-        enforce_authorization(
-            &security_context,
-            &Resource::Topic(stream_message.msg_id.topic_name.clone()),
-            Permission::Produce,
-            &self.service.resources.security,
-        ).await?;
 
         trace!(
             message_id = %stream_message.request_id,
@@ -149,18 +142,29 @@ impl ProducerService for DanubeServerImpl {
 
         let service = self.service.as_ref();
 
-        // check if the producer exist
-        if !service
-            .topic_manager
-            .producers
-            .contains(stream_message.msg_id.producer_id)
-        {
-            let status = Status::not_found(format!(
-                "The producer with id {} does not exist",
-                stream_message.msg_id.producer_id
-            ));
-            counter!(BROKER_RPC_TOTAL.name, "service"=>"producer", "method"=>"send_message", "result"=>"error").increment(1);
-            return Err(status);
+        // Fast-path authorization: verify the producer session is active and registered to this topic.
+        // Full multi-scope RBAC authorization was already enforced at connection/creation time in `create_producer`.
+        match service.topic_manager.producers.get_topic(stream_message.msg_id.producer_id) {
+            Some(ref registered_topic) if registered_topic == &stream_message.msg_id.topic_name => {
+                // Producer is valid and authorized for this topic
+            }
+            Some(_) => {
+                let status = Status::permission_denied(format!(
+                    "The producer with id {} is not authorized for topic {}",
+                    stream_message.msg_id.producer_id,
+                    stream_message.msg_id.topic_name
+                ));
+                counter!(BROKER_RPC_TOTAL.name, "service"=>"producer", "method"=>"send_message", "result"=>"error").increment(1);
+                return Err(status);
+            }
+            None => {
+                let status = Status::not_found(format!(
+                    "The producer with id {} does not exist",
+                    stream_message.msg_id.producer_id
+                ));
+                counter!(BROKER_RPC_TOTAL.name, "service"=>"producer", "method"=>"send_message", "result"=>"error").increment(1);
+                return Err(status);
+            }
         }
 
         let req_id = stream_message.request_id;

--- a/danube-broker/src/broker_service.rs
+++ b/danube-broker/src/broker_service.rs
@@ -89,7 +89,7 @@ impl BrokerService {
         let consumers = ConsumerRegistry::new();
         let topic_registry = Arc::new(TopicRegistry::new(None));
         let resources_arc = Arc::new(resources);
-        let metrics_collector = Arc::new(MetricsCollector::new());
+        let metrics_collector = Arc::new(MetricsCollector::with_registry(topic_registry.clone()));
         let replicator = Arc::new(Replicator::new(broker_id));
 
         let topic_manager = TopicManager::new(
@@ -488,10 +488,9 @@ impl BrokerService {
         producer_name: &str,
     ) -> Option<u64> {
         let topic = self.topic_registry.get_topic(topic_name)?;
-        let producers = topic.producers.lock().await;
-        for (_id, producer) in producers.iter() {
-            if producer.producer_name == producer_name {
-                return Some(producer.producer_id);
+        for entry in topic.producers.iter() {
+            if entry.value().producer_name == producer_name {
+                return Some(entry.value().producer_id);
             }
         }
         None

--- a/danube-broker/src/danube_service/metrics_collector.rs
+++ b/danube-broker/src/danube_service/metrics_collector.rs
@@ -9,6 +9,7 @@
 //! - Scraping our own HTTP endpoint is inefficient
 //! - We need real-time access without HTTP overhead
 
+use crate::topic_registry::TopicRegistry;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -32,21 +33,37 @@ pub(crate) struct TopicMetricsSnapshot {
 
 /// Global metrics collector
 /// 
-/// This structure is updated whenever metrics are recorded. It provides
-/// fast read access for LoadReport generation without scraping endpoints.
+/// This structure pulls metrics directly from registered topics on demand for
+/// LoadReport generation, eliminating write-lock contention on message publishing.
 #[derive(Debug, Clone)]
 pub(crate) struct MetricsCollector {
+    topic_registry: Arc<RwLock<Option<Arc<TopicRegistry>>>>,
     topics: Arc<RwLock<HashMap<String, TopicMetricsSnapshot>>>,
 }
 
 impl MetricsCollector {
     pub fn new() -> Self {
         Self {
+            topic_registry: Arc::new(RwLock::new(None)),
             topics: Arc::new(RwLock::new(HashMap::new())),
         }
     }
+
+    pub fn with_registry(registry: Arc<TopicRegistry>) -> Self {
+        Self {
+            topic_registry: Arc::new(RwLock::new(Some(registry))),
+            topics: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn set_topic_registry(&self, registry: Arc<TopicRegistry>) {
+        let mut reg = self.topic_registry.write().await;
+        *reg = Some(registry);
+    }
     
-    /// Record a message published to a topic
+    /// Record a message published to a topic (legacy fallback)
+    #[allow(dead_code)]
     pub async fn record_message_in(&self, topic_name: &str, bytes: u64) {
         let mut topics = self.topics.write().await;
         let snapshot = topics.entry(topic_name.to_string()).or_default();
@@ -85,16 +102,41 @@ impl MetricsCollector {
     }
     
     /// Get snapshot for a specific topic
-    /// Currently unused - we use get_all_snapshots() instead
     #[allow(dead_code)]
     pub async fn get_topic_snapshot(&self, topic_name: &str) -> Option<TopicMetricsSnapshot> {
+        let registry_opt = {
+            self.topic_registry.read().await.clone()
+        };
+
+        if let Some(registry) = registry_opt {
+            if let Some(topic) = registry.get_topic(topic_name) {
+                return Some(topic.metrics_snapshot().await);
+            }
+        }
         let topics = self.topics.read().await;
         topics.get(topic_name).cloned()
     }
     
     /// Get all topic snapshots
     pub async fn get_all_snapshots(&self) -> HashMap<String, TopicMetricsSnapshot> {
-        self.topics.read().await.clone()
+        let registry_opt = {
+            self.topic_registry.read().await.clone()
+        };
+
+        if let Some(registry) = registry_opt {
+            let mut result = HashMap::new();
+            for (name, topic) in registry.get_all_topic_instances() {
+                result.insert(name, topic.metrics_snapshot().await);
+            }
+            // Include fallback entries if any exist
+            let fallback = self.topics.read().await;
+            for (k, v) in fallback.iter() {
+                result.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+            result
+        } else {
+            self.topics.read().await.clone()
+        }
     }
     
     /// Remove a topic (when it's deleted)

--- a/danube-broker/src/dispatcher.rs
+++ b/danube-broker/src/dispatcher.rs
@@ -222,12 +222,22 @@ impl Dispatcher {
         }
     }
 
-    pub(crate) async fn wake_dispatch(&self) -> Result<()> {
+    pub(crate) fn wake_dispatch(&self) -> Result<()> {
         match &self.handle {
-            DispatcherHandle::Reliable { control_tx, .. } => control_tx
-                .send(DispatcherCommand::PollAndDispatch)
-                .await
-                .map_err(|_| anyhow!("Failed to wake dispatcher")),
+            DispatcherHandle::Reliable { control_tx, .. } => {
+                match control_tx.try_send(DispatcherCommand::PollAndDispatch) {
+                    Ok(()) => Ok(()),
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        // Coalesce wakeups: a poll command is already queued in the control channel.
+                        // Since the reliable dispatch loop drains messages until no more are ready
+                        // or the window is exhausted, dropping redundant poll signals is completely safe.
+                        Ok(())
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        Err(anyhow!("Failed to wake dispatcher: channel closed"))
+                    }
+                }
+            }
             _ => Ok(()),
         }
     }

--- a/danube-broker/src/dispatcher/exclusive_test.rs
+++ b/danube-broker/src/dispatcher/exclusive_test.rs
@@ -116,7 +116,7 @@ async fn reliable_single_ack_gating() {
 
     // Append the first message AFTER engine init; then notify to trigger dispatch loop
     ts.store_message(make_msg(100, 0, topic)).await.unwrap();
-    dispatcher.wake_dispatch().await.expect("wake first");
+    dispatcher.wake_dispatch().expect("wake first");
 
     // Expect first message (should be the only one available)
     let first = timeout(Duration::from_secs(2), rx.recv())
@@ -139,7 +139,7 @@ async fn reliable_single_ack_gating() {
 
     // Append the second message NOW; then notify to trigger next dispatch
     ts.store_message(make_msg(101, 1, topic)).await.unwrap();
-    dispatcher.wake_dispatch().await.expect("wake second");
+    dispatcher.wake_dispatch().expect("wake second");
 
     // Expect second message
     let second = timeout(Duration::from_secs(2), rx.recv())

--- a/danube-broker/src/dispatcher/shared_test.rs
+++ b/danube-broker/src/dispatcher/shared_test.rs
@@ -122,7 +122,7 @@ async fn reliable_multiple_round_robin_ack_gating() {
 
     // Append first message and notify -> expect delivery to one of the consumers
     ts.store_message(make_msg(500, 0, topic)).await.unwrap();
-    dispatcher.wake_dispatch().await.expect("wake first");
+    dispatcher.wake_dispatch().expect("wake first");
 
     // Expect first delivery to either c1 or c2
     let first_delivered = timeout(Duration::from_secs(2), async {
@@ -146,7 +146,7 @@ async fn reliable_multiple_round_robin_ack_gating() {
 
     // Append second message and notify -> expect other consumer to receive next (round-robin)
     ts.store_message(make_msg(501, 1, topic)).await.unwrap();
-    dispatcher.wake_dispatch().await.expect("wake second");
+    dispatcher.wake_dispatch().expect("wake second");
 
     let second_delivered = timeout(Duration::from_secs(2), async {
         tokio::select! {

--- a/danube-broker/src/topic.rs
+++ b/danube-broker/src/topic.rs
@@ -5,10 +5,12 @@ use danube_core::{
     storage::{PersistentStorage, StartPosition, TopicStream},
 };
 use danube_schema::{SchemaResources, TopicSchemaContext};
+use dashmap::DashMap;
 use metrics::{counter, gauge, histogram};
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tokio::time::Duration;
 use tracing::{debug, warn};
 
@@ -17,7 +19,7 @@ use crate::{
         TOPIC_ACTIVE_SUBSCRIPTIONS, TOPIC_BYTES_IN_TOTAL, TOPIC_MESSAGES_IN_TOTAL,
         TOPIC_MESSAGE_SIZE_BYTES,
     },
-    danube_service::metrics_collector::MetricsCollector,
+    danube_service::metrics_collector::{MetricsCollector, TopicMetricsSnapshot},
     dispatcher::{DispatchStrategy, Dispatcher},
     message::{AckMessage, NackMessage},
     policies::Policies,
@@ -59,9 +61,12 @@ pub(crate) struct Topic {
     // Topic-level policies
     pub(crate) topic_policies: Option<Policies>,
     // subscription_name -> Subscription
-    pub(crate) subscriptions: Mutex<HashMap<String, Subscription>>,
+    pub(crate) subscriptions: RwLock<HashMap<String, Subscription>>,
     // the producers currently connected to this topic, producer_id -> Producer
-    pub(crate) producers: Mutex<HashMap<u64, Producer>>,
+    pub(crate) producers: DashMap<u64, Producer>,
+    // Ingress counters for LoadReport and monitoring (lock-free)
+    pub(crate) messages_in: AtomicU64,
+    pub(crate) bytes_in: AtomicU64,
     // the retention strategy for the topic, Reliable vs NonReliable
     pub(crate) dispatch_strategy: DispatchStrategy,
     // handle to metadata topic resources for cleanup operations
@@ -100,8 +105,10 @@ impl Topic {
             topic_name: topic_name.into(),
             schema_context: TopicSchemaContext::new(resources_schema),
             topic_policies: None,
-            subscriptions: Mutex::new(HashMap::new()),
-            producers: Mutex::new(HashMap::new()),
+            subscriptions: RwLock::new(HashMap::new()),
+            producers: DashMap::new(),
+            messages_in: AtomicU64::new(0),
+            bytes_in: AtomicU64::new(0),
             dispatch_strategy,
             resources_topic,
             topic_store,
@@ -115,19 +122,31 @@ impl Topic {
 
     /// Get current producer count for metrics
     pub(crate) async fn get_producer_count(&self) -> usize {
-        self.producers.lock().await.len()
+        self.producers.len()
     }
 
     /// Get current consumer count for metrics (across all subscriptions)
     pub(crate) async fn get_consumer_count(&self) -> usize {
-        let subscriptions = self.subscriptions.lock().await;
+        let subscriptions = self.subscriptions.read().await;
         subscriptions.values().map(|sub| sub.consumer_count()).sum()
     }
 
     /// Get subscription count for metrics
     #[allow(dead_code)]
     pub(crate) async fn get_subscription_count(&self) -> usize {
-        self.subscriptions.lock().await.len()
+        self.subscriptions.read().await.len()
+    }
+
+    /// Returns a snapshot of topic metrics for LoadReport generation
+    pub(crate) async fn metrics_snapshot(&self) -> TopicMetricsSnapshot {
+        TopicMetricsSnapshot {
+            messages_in_total: self.messages_in.load(Ordering::Relaxed),
+            bytes_in_total: self.bytes_in.load(Ordering::Relaxed),
+            active_producers: self.producers.len(),
+            active_consumers: self.get_consumer_count().await,
+            active_subscriptions: self.subscriptions.read().await.len(),
+            total_backlog_messages: 0,
+        }
     }
 
     #[allow(unused_assignments)]
@@ -139,24 +158,19 @@ impl Topic {
     ) -> Result<serde_json::Value> {
         // Policy: max_producers_per_topic
         self.can_add_producer().await?;
-        let mut producer_config = serde_json::Value::String(String::new());
-        let mut producers = self.producers.lock().await;
+        let new_producer = Producer::new(
+            producer_id,
+            producer_name.into(),
+            self.topic_name.clone(),
+            producer_access_mode,
+        );
+        let producer_config = serde_json::to_value(&new_producer)?;
 
-        match producers.entry(producer_id) {
-            Entry::Vacant(entry) => {
-                let new_producer = Producer::new(
-                    producer_id,
-                    producer_name.into(),
-                    self.topic_name.clone(),
-                    producer_access_mode,
-                );
-
-                producer_config = serde_json::to_value(&new_producer)?;
-
+        match self.producers.entry(producer_id) {
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
                 entry.insert(new_producer);
             }
-            Entry::Occupied(entry) => {
-                //let current_producer = entry.get();
+            dashmap::mapref::entry::Entry::Occupied(entry) => {
                 debug!(producer_id = %entry.key(), topic = %self.topic_name, "producer already exists");
                 return Err(anyhow!(" the producer already exist"));
             }
@@ -171,9 +185,8 @@ impl Topic {
 
         // Disconnect all the topic producers
         {
-            let mut producers = self.producers.lock().await;
-            for (_, producer) in producers.iter_mut() {
-                let producer_id = producer.disconnect();
+            for mut entry in self.producers.iter_mut() {
+                let producer_id = entry.value_mut().disconnect();
                 disconnected_producers.push(producer_id);
             }
 
@@ -184,7 +197,7 @@ impl Topic {
         }
 
         // Disconnect all the topic subscriptions
-        let mut subs_guard = self.subscriptions.lock().await;
+        let mut subs_guard = self.subscriptions.write().await;
         for (_, subscription) in subs_guard.iter_mut() {
             let mut consumers = subscription.disconnect().await?;
             disconnected_consumers.append(&mut consumers);
@@ -247,17 +260,14 @@ impl Topic {
             .validate_message(&stream_message, &self.topic_name)
             .await?;
 
-            let producer_id = stream_message.msg_id.producer_id;
-            {
-                let producers = self.producers.lock().await;
-                if !producers.contains_key(&producer_id) {
-                    return Err(anyhow!(
-                        "the producer with id {} is not attached to topic name: {}",
-                        producer_id,
-                        self.topic_name
-                    ));
-                }
-            }
+        let producer_id = stream_message.msg_id.producer_id;
+        if !self.producers.contains_key(&producer_id) {
+            return Err(anyhow!(
+                "the producer with id {} is not attached to topic name: {}",
+                producer_id,
+                self.topic_name
+            ));
+        }
 
         // Update ingress counters (topic only)
         counter!(
@@ -271,10 +281,9 @@ impl Topic {
         )
         .increment(stream_message.payload.len() as u64);
 
-        // Dual-track metrics for LoadReport
-        self.metrics_collector
-            .record_message_in(&self.topic_name, stream_message.payload.len() as u64)
-            .await;
+        // Update internal atomic counters for LoadReport (lock-free)
+        self.messages_in.fetch_add(1, Ordering::Relaxed);
+        self.bytes_in.fetch_add(stream_message.payload.len() as u64, Ordering::Relaxed);
 
         // Process message based on dispatch strategy
         match &self.dispatch_strategy {
@@ -304,7 +313,7 @@ impl Topic {
     async fn dispatch_to_subscriptions_async(&self, stream_message: StreamMessage) -> Result<()> {
         // Phase 1: snapshot dispatchers under lock (cheap clone — just channel handles)
         let targets: Vec<(String, Dispatcher)> = {
-            let subs = self.subscriptions.lock().await;
+            let subs = self.subscriptions.read().await;
             subs.iter()
                 .filter_map(|(name, sub)| {
                     sub.dispatcher.as_ref().map(|d| (name.clone(), d.clone()))
@@ -329,7 +338,7 @@ impl Topic {
 
         // Phase 3: re-lock only to mark failures idle
         if !idle_names.is_empty() {
-            let mut subs = self.subscriptions.lock().await;
+            let mut subs = self.subscriptions.write().await;
             for name in &idle_names {
                 if let Some(sub) = subs.get_mut(name) {
                     sub.mark_idle();
@@ -358,7 +367,7 @@ impl Topic {
 
     async fn wake_reliable_dispatchers(&self) {
         let dispatchers: Vec<Dispatcher> = {
-            let subscriptions = self.subscriptions.lock().await;
+            let subscriptions = self.subscriptions.read().await;
             subscriptions
                 .values()
                 .filter_map(|subscription| subscription.dispatcher.clone())
@@ -366,7 +375,7 @@ impl Topic {
         };
 
         for dispatcher in dispatchers {
-            if let Err(err) = dispatcher.wake_dispatch().await {
+            if let Err(err) = dispatcher.wake_dispatch() {
                 debug!(
                     topic = %self.topic_name,
                     error = %err,
@@ -377,31 +386,25 @@ impl Topic {
     }
 
     pub(crate) async fn ack_message(&self, ack_msg: AckMessage) -> Result<()> {
-        let mut subscriptions = self.subscriptions.lock().await;
+        let subscriptions = self.subscriptions.read().await;
         let subscription = subscriptions
-            .get_mut(ack_msg.subscription_name.as_str())
+            .get(ack_msg.subscription_name.as_str())
             .ok_or_else(|| anyhow!("Subscription not found"))?;
         subscription.ack_message(ack_msg).await?;
         Ok(())
     }
 
     pub(crate) async fn nack_message(&self, nack_msg: NackMessage) -> Result<()> {
-        let mut subscriptions = self.subscriptions.lock().await;
+        let subscriptions = self.subscriptions.read().await;
         let subscription = subscriptions
-            .get_mut(nack_msg.subscription_name.as_str())
+            .get(nack_msg.subscription_name.as_str())
             .ok_or_else(|| anyhow!("Subscription not found"))?;
         subscription.nack_message(nack_msg).await?;
         Ok(())
     }
 
     pub(crate) async fn get_producer_status(&self, producer_id: u64) -> bool {
-        let producers = self.producers.lock().await;
-        if let Some(producer) = producers.get(&producer_id) {
-            if producer.status == true {
-                return true;
-            }
-        }
-        false
+        self.producers.get(&producer_id).map_or(false, |p| p.status)
     }
 
     // Subscribe to the topic and create a consumer for receiving messages
@@ -416,7 +419,7 @@ impl Topic {
 
         // Check if subscription already exists without holding the lock across awaits
         let is_new = {
-            let subs = self.subscriptions.lock().await;
+            let subs = self.subscriptions.read().await;
             !subs.contains_key(&options.subscription_name)
         };
 
@@ -475,7 +478,7 @@ impl Topic {
             }
 
             // Insert the new subscription
-            let mut subs = self.subscriptions.lock().await;
+            let mut subs = self.subscriptions.write().await;
             subs.insert(options.subscription_name.clone(), new_subscription);
             // Gauge: topic active subscriptions ++
             gauge!(TOPIC_ACTIVE_SUBSCRIPTIONS.name, "topic" => self.topic_name.clone())
@@ -492,7 +495,7 @@ impl Topic {
             .await?;
 
         // Retrieve the subscription and proceed
-        let mut subs = self.subscriptions.lock().await;
+        let mut subs = self.subscriptions.write().await;
         let subscription = subs
             .get_mut(&options.subscription_name)
             .expect("subscription must exist at this point");
@@ -512,7 +515,7 @@ impl Topic {
     // should be called if all consumers are disconnected
     pub(crate) async fn unsubscribe(&self, subscription_name: &str) {
         let subs_count = {
-            let mut subs = self.subscriptions.lock().await;
+            let mut subs = self.subscriptions.write().await;
             subs.remove(subscription_name);
             subs.len()
         };
@@ -534,7 +537,7 @@ impl Topic {
         let mut removed_consumers = Vec::new();
 
         {
-            let subs = self.subscriptions.lock().await;
+            let subs = self.subscriptions.read().await;
             for (name, sub) in subs.iter() {
                 if let Some(idle_since) = sub.idle_since {
                     if now.duration_since(idle_since) > grace_period {
@@ -573,7 +576,7 @@ impl Topic {
         subscription_name: &str,
         consumer_name: &str,
     ) -> Option<u64> {
-        let mut sub_guard = self.subscriptions.lock().await;
+        let mut sub_guard = self.subscriptions.write().await;
         let subscription = match sub_guard.get_mut(subscription_name) {
             Some(subscr) => subscr,
             None => return None,
@@ -589,7 +592,7 @@ impl Topic {
 
     // check_subscription checks if the subscription is activelly used by any consumer
     pub(crate) async fn check_subscription(&self, subscription: &str) -> Option<bool> {
-        let sub_guard = self.subscriptions.lock().await;
+        let sub_guard = self.subscriptions.read().await;
         let subs = sub_guard.get(subscription)?;
 
         let consumers = subs.get_consumers();
@@ -664,18 +667,17 @@ impl Topic {
     }
 
     // ===== Helper counters =====
+    #[allow(dead_code)]
     pub(crate) async fn producer_count(&self) -> usize {
-        let producers = self.producers.lock().await;
-        producers.len()
+        self.producers.len()
     }
 
     pub(crate) async fn subscription_count(&self) -> usize {
-        let subscriptions = self.subscriptions.lock().await;
-        subscriptions.len()
+        self.subscriptions.read().await.len()
     }
 
     pub(crate) async fn total_consumer_count(&self) -> usize {
-        let subscriptions = self.subscriptions.lock().await;
+        let subscriptions = self.subscriptions.read().await;
         let mut total = 0usize;
         for (_name, sub) in subscriptions.iter() {
             total += sub.consumer_count();
@@ -693,7 +695,7 @@ impl Topic {
         if limit == 0 {
             return Ok(());
         }
-        let current = self.producer_count().await as u32;
+        let current = self.producers.len() as u32;
         if current >= limit {
             return Err(anyhow!(
                 "Producer limit reached for topic {}. Current: {}, Limit: {}",
@@ -734,7 +736,7 @@ impl Topic {
             .map(|p| p.get_max_consumers_per_subscription())
             .unwrap_or(0);
         if per_sub_limit > 0 {
-            let subscriptions = self.subscriptions.lock().await;
+            let subscriptions = self.subscriptions.read().await;
             if let Some(sub) = subscriptions.get(sub_name) {
                 let current = sub.consumer_count() as u32;
                 if current >= per_sub_limit {

--- a/danube-broker/src/topic_control.rs
+++ b/danube-broker/src/topic_control.rs
@@ -439,7 +439,7 @@ impl TopicManager {
     /// Best-effort flush of all subscription cursors for a topic (reliable only).
     async fn flush_subscription_cursors(&self, topic_name: &str) -> Result<()> {
         if let Some(topic) = self.topic_registry.get_topic(topic_name) {
-            let subscriptions = topic.subscriptions.lock().await;
+            let subscriptions = topic.subscriptions.read().await;
             for (_sub_name, subscription) in subscriptions.iter() {
                 if let Some(dispatcher) = &subscription.dispatcher {
                     let _ = dispatcher.flush_progress_now().await;
@@ -539,7 +539,7 @@ impl TopicManager {
 
         if let Some(topic) = self.topic_registry.get_topic(&topic_name) {
             let failure_policy = {
-                let subscriptions = topic.subscriptions.lock().await;
+                let subscriptions = topic.subscriptions.read().await;
                 subscriptions
                     .get(&subscription_options.subscription_name)
                     .map(|subscription| subscription.failure_policy.clone())
@@ -564,7 +564,7 @@ impl TopicManager {
     pub(crate) async fn find_consumer_by_id(&self, consumer_id: u64) -> Option<Consumer> {
         if let Some((topic_name, subscription_name)) = self.consumers.get(consumer_id) {
             if let Some(topic) = self.topic_registry.get_topic(&topic_name) {
-                if let Some(subscription) = topic.subscriptions.lock().await.get(&subscription_name)
+                if let Some(subscription) = topic.subscriptions.read().await.get(&subscription_name)
                 {
                     return subscription.get_consumer(consumer_id);
                 }
@@ -606,7 +606,7 @@ impl TopicManager {
         if let Some((topic_name, subscription_name)) = self.consumers.get(consumer_id) {
             if let Some(topic) = self.topic_registry.get_topic(&topic_name) {
                 let dispatcher = {
-                    let subscriptions = topic.subscriptions.lock().await;
+                    let subscriptions = topic.subscriptions.read().await;
                     subscriptions
                         .get(&subscription_name)
                         .and_then(|subscription| subscription.dispatcher.clone())
@@ -616,7 +616,7 @@ impl TopicManager {
                     if let Err(e) = dispatcher.reset_pending(consumer_id).await {
                         tracing::warn!(consumer_id = %consumer_id, error = %e, "failed to reset pending state");
                     }
-                    if let Err(e) = dispatcher.wake_dispatch().await {
+                    if let Err(e) = dispatcher.wake_dispatch() {
                         tracing::warn!(consumer_id = %consumer_id, error = %e, "failed to wake dispatcher");
                     }
                 }
@@ -871,6 +871,7 @@ impl ProducerRegistry {
     }
 
     /// Returns true if a `producer_id` is registered.
+    #[allow(dead_code)]
     pub(crate) fn contains(&self, producer_id: u64) -> bool {
         self.0.contains_key(&producer_id)
     }

--- a/danube-broker/src/topic_registry.rs
+++ b/danube-broker/src/topic_registry.rs
@@ -98,6 +98,14 @@ impl TopicRegistry {
         self.topics.iter().map(|entry| entry.key().clone()).collect()
     }
 
+    /// Returns all registered topics and their Arc<Topic> handles.
+    pub fn get_all_topic_instances(&self) -> Vec<(String, Arc<Topic>)> {
+        self.topics
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect()
+    }
+
     /// Check if a topic exists in the registry
     pub fn contains_topic(&self, topic_name: &str) -> bool {
         self.topics.contains_key(topic_name)

--- a/danube-broker/src/topic_tests.rs
+++ b/danube-broker/src/topic_tests.rs
@@ -193,7 +193,7 @@ async fn reliable_subscription_materializes_with_persisted_failure_policy() -> A
         .await?
         .expect("stored failure policy");
 
-    let subscriptions = topic.subscriptions.lock().await;
+    let subscriptions = topic.subscriptions.read().await;
     let subscription = subscriptions.get("sub-a").expect("subscription exists");
 
     assert_eq!(subscription.failure_policy, stored_policy);
@@ -457,7 +457,7 @@ async fn non_reliable_topic_publish_does_not_stall_on_full_subscription() -> Any
         .await?;
 
     let (slow_consumer, fast_consumer) = {
-        let subs = topic.subscriptions.lock().await;
+        let subs = topic.subscriptions.read().await;
         let slow = subs
             .get("slow-sub")
             .and_then(|sub| sub.get_consumer(slow_consumer_id))


### PR DESCRIPTION
- Eliminate global RwLock write-lock contention in MetricsCollector by adding lock-free AtomicU64 counters (messages_in, bytes_in) directly to Topic and pulling snapshots on demand from TopicRegistry.
- Bypass redundant RBAC re-authorization on produce hot path in send_message by validating producer session and topic attachment against the in-memory ProducerRegistry.
- Reduce Topic mutex contention by upgrading producers to DashMap and subscriptions to tokio::sync::RwLock so publishes and consumer ACKs proceed concurrently without cross-blocking.
- Coalesce Dispatcher PollAndDispatch wakeups in wake_reliable_dispatchers via synchronous non-blocking try_send, eliminating publisher backpressure.