### PR TITLE
perf(broker): implement direct channel delivery for consumer streamin…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ brokers:
 		mkdir -p "$$data_dir"; \
 		echo "Starting broker $$i: client=$$broker_port admin=$$admin_port raft=$$raft_port prom=$$prom_port"; \
 		RUST_LOG=$(LOG_LEVEL) RUST_BACKTRACE=1 \
-		./target/release/danube-broker \
+		nohup ./target/release/danube-broker \
 		    --config-file $(CONFIG_FILE) \
 		    --broker-addr "0.0.0.0:$$broker_port" \
 		    --admin-addr "0.0.0.0:$$admin_port" \
@@ -125,7 +125,7 @@ broker-start:
 	mkdir -p "$$data_dir"; \
 	echo "Starting broker $(ID): client=$$broker_port admin=$$admin_port raft=$$raft_port prom=$$prom_port"; \
 	RUST_LOG=$(LOG_LEVEL) RUST_BACKTRACE=1 \
-	./target/release/danube-broker \
+	nohup ./target/release/danube-broker \
 	    --config-file $(CONFIG_FILE) \
 	    --broker-addr "0.0.0.0:$$broker_port" \
 	    --admin-addr "0.0.0.0:$$admin_port" \

--- a/danube-broker/src/admin/topics_admin.rs
+++ b/danube-broker/src/admin/topics_admin.rs
@@ -349,11 +349,37 @@ impl TopicAdmin for DanubeAdminImpl {
             .failure_policy
             .ok_or_else(|| Status::invalid_argument("failure_policy must be provided"))?;
 
-        let dispatch_strategy = self
-            .resources
-            .topic
-            .get_dispatch_strategy(req.topic.trim_start_matches('/'))
-            .await;
+        let lookup = req.topic.trim_start_matches('/');
+        let mut dispatch_strategy = self.resources.topic.get_dispatch_strategy(lookup).await;
+
+        if dispatch_strategy.is_none() {
+            if let Some(topic) = self
+                .broker_service
+                .topic_registry
+                .get_topic(&req.topic)
+                .or_else(|| self.broker_service.topic_registry.get_topic(lookup))
+            {
+                dispatch_strategy = match topic.dispatch_strategy {
+                    crate::dispatcher::DispatchStrategy::Reliable => {
+                        Some(ConfigDispatchStrategy::Reliable)
+                    }
+                    crate::dispatcher::DispatchStrategy::NonReliable => {
+                        Some(ConfigDispatchStrategy::NonReliable)
+                    }
+                };
+            }
+        }
+
+        if dispatch_strategy.is_none() {
+            // Allow Raft metadata replication to catch up on followers when topic was just created
+            for _ in 0..10 {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                dispatch_strategy = self.resources.topic.get_dispatch_strategy(lookup).await;
+                if dispatch_strategy.is_some() {
+                    break;
+                }
+            }
+        }
 
         if !matches!(dispatch_strategy, Some(ConfigDispatchStrategy::Reliable)) {
             return Err(Status::failed_precondition(

--- a/danube-broker/src/broker_server/consumer_handler.rs
+++ b/danube-broker/src/broker_server/consumer_handler.rs
@@ -8,7 +8,6 @@ use danube_core::proto::{
 
 use crate::broker_metrics::BROKER_RPC_TOTAL;
 use metrics::counter;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use crate::security::authz::{enforce_authorization, Permission, Resource};
@@ -64,11 +63,9 @@ impl ConsumerService for DanubeServerImpl {
         {
             // Single-attach takeover at subscribe: cancel existing stream and prepare for new session
             if let Some(consumer) = service.find_consumer_by_id(consumer_id).await {
-                // Simplified takeover: cancel existing streaming task and mark active
-                consumer.session.lock().await.cancel_stream();
-                consumer.set_status_active().await;
-                // Reset dispatcher pending state and notify to resume polling (reliable mode)
-                service.trigger_dispatcher_on_reconnect(consumer_id).await;
+                // Simplified takeover: cancel existing streaming task and prepare for new stream
+                consumer.cancel_stream().await;
+                consumer.set_status_inactive().await;
             }
 
             let response = ConsumerResponse {
@@ -176,7 +173,7 @@ impl ConsumerService for DanubeServerImpl {
 
         let service = self.service.as_ref();
 
-        // Fetch Consumer (which contains session with rx_cons)
+        // Fetch Consumer
         let consumer = if let Some(cons) = service.find_consumer_for_streaming(consumer_id).await {
             cons
         } else {
@@ -188,69 +185,33 @@ impl ConsumerService for DanubeServerImpl {
             return Err(status);
         };
 
-        // Note: takeover is handled during subscribe(); here we only attach a new stream
+        // Attach direct gRPC stream to consumer and obtain session cancellation token
+        let (token_for_task, session_id) = consumer.attach_stream(grpc_tx.clone()).await;
 
-        let rx_cons_cloned = Arc::clone(&consumer.rx_cons);
+        // Reset dispatcher pending state and wake dispatcher to begin streaming immediately
+        self.service.trigger_dispatcher_on_reconnect(consumer_id).await;
+
         let service_for_disconnect = self.service.clone();
 
-        // Takeover: cancel old session and get new cancellation token
-        let token_for_task = consumer.session.lock().await.takeover();
-
+        // Spawn lightweight disconnect watcher task (zero CPU on message path)
         tokio::spawn(async move {
-            let mut rx_guard = rx_cons_cloned.lock().await;
-
-            loop {
-                tokio::select! {
-                    // If the gRPC response stream is dropped (client disconnected), mark inactive
-                    _ = grpc_tx.closed() => {
-                        warn!(
-                            consumer_id = %consumer_id,
-                            "Client disconnected, marking consumer inactive"
-                        );
-                        if let Some(consumer) = service_for_disconnect
-                            .find_consumer_by_id(consumer_id)
-                            .await
-                        {
-                            consumer.set_status_inactive().await;
-                            // Reset dispatcher pending state so buffered messages can fail over/redeliver
-                            service_for_disconnect.trigger_dispatcher_on_reconnect(consumer_id).await;
-                        }
-                        break;
-                    }
-                    // Check for cancellation
-                    _ = token_for_task.cancelled() => {
-                        trace!(consumer_id = %consumer_id, "streaming task cancelled");
-                        // Don't modify consumer status on cancellation - new connection might be active
-                        break;
-                    }
-                    // Receive messages
-                    message = rx_guard.recv() => {
-                        match message {
-                            Some(stream_message) => {
-                                if grpc_tx.send(Ok(stream_message.into())).await.is_err() {
-                                    // Error handling for when the client disconnects
-                                    warn!(
-                                        consumer_id = %consumer_id,
-                                        "client disconnected, marking consumer inactive"
-                                    );
-
-                                    // Mark the consumer as inactive on disconnect
-                                    if let Some(consumer) = service_for_disconnect
-                                        .find_consumer_by_id(consumer_id)
-                                        .await
-                                    {
-                                        consumer.set_status_inactive().await;
-                                        // Reset dispatcher pending state so buffered messages can fail over/redeliver
-                                        service_for_disconnect.trigger_dispatcher_on_reconnect(consumer_id).await;
-                                    }
-                                    break;
-                                }
-                            }
-                            None => {
-                                // Channel closed
-                                break;
-                            }
-                        }
+            tokio::select! {
+                biased;
+                _ = token_for_task.cancelled() => {
+                    trace!(consumer_id = %consumer_id, session_id = %session_id, "streaming task cancelled");
+                }
+                _ = grpc_tx.closed() => {
+                    warn!(
+                        consumer_id = %consumer_id,
+                        session_id = %session_id,
+                        "Client disconnected, marking consumer inactive"
+                    );
+                    if let Some(consumer) = service_for_disconnect
+                        .find_consumer_by_id(consumer_id)
+                        .await
+                    {
+                        consumer.detach_stream_if_session(session_id).await;
+                        service_for_disconnect.trigger_dispatcher_on_reconnect(consumer_id).await;
                     }
                 }
             }

--- a/danube-broker/src/consumer.rs
+++ b/danube-broker/src/consumer.rs
@@ -1,105 +1,107 @@
 use anyhow::{anyhow, Result};
 use danube_core::message::StreamMessage;
+use danube_core::proto::StreamMessage as ProtoStreamMessage;
 use metrics::counter;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
+use tonic::Status;
 use tracing::{debug, trace, warn};
 
 use crate::broker_metrics::{CONSUMER_BYTES_OUT_TOTAL, CONSUMER_MESSAGES_OUT_TOTAL};
 use crate::utils::get_random_id;
 
+/// Sender type for direct streaming to gRPC client.
+pub(crate) type StreamSender = mpsc::Sender<Result<ProtoStreamMessage, Status>>;
+
 /// Represents a consumer connected and associated with a Subscription.
 ///
-/// # Architecture Overview
+/// # Architecture Overview (Direct Channel Delivery)
 ///
-/// The Consumer struct manages the complete message pipeline from dispatcher to client:
+/// The Consumer struct delivers messages directly from the dispatcher to Tonic's gRPC stream channel:
 ///
 /// ```text
 /// ┌──────────────────────────────────────────────────────────────────────────────┐
-/// │                           MESSAGE FLOW PIPELINE                               │
+/// │                      DIRECT MESSAGE FLOW PIPELINE                            │
 /// └──────────────────────────────────────────────────────────────────────────────┘
 ///
-///  1. Producer      2. Dispatcher         3. Internal       4. gRPC          5. Client
-///     publishes        routes to             Channel          Stream             App
-///     message          consumer              buffers          sends
-///       │                 │                     │               │                 │
-///       ├─────────────────▶                     │               │                 │
-///       │ send_message()  │                     │               │                 │
-///       │ or              │                     │               │                 │
-///       │ try_send_message()                    │               │                 │
-///       │                 │                     │               │                 │
-///       │                 │ tx_cons.send()      │               │                 │
-///       │                 │ or tx_cons.try_send()               │                 │
-///       │                 ├────────────────────▶│               │                 │
-///       │                 │    (Producer)       │               │                 │
-///       │                 │                     │  rx_cons      │                 │
-///       │                 │                     │  .recv()      │                 │
-///       │                 │                     ├──────────────▶│                 │
-///       │                 │                     │  (Consumer)   │                 │
-///       │                 │                     │               │  grpc_tx.send() │
-///       │                 │                     │               ├────────────────▶│
-///       │                 │                     │               │                 │
-///       ▼                 ▼                     ▼               ▼                 ▼
+///  1. Producer      2. Dispatcher                       3. gRPC Stream        4. Client
+///     publishes        routes to consumer                  sends to client        App
+///       │                 │                                     │                  │
+///       ├─────────────────▶                                     │                  │
+///       │                 │ send_message().await                │                  │
+///       │                 │ or try_send_message()               │                  │
+///       │                 │                                     │                  │
+///       │                 │ msg.into() -> stream_sender.send()  │                  │
+///       │                 ├────────────────────────────────────▶│                  │
+///       │                 │                                     │  HTTP/2 data     │
+///       │                 │                                     ├─────────────────▶│
+///       │                 │                                     │                  │
+///       ▼                 ▼                                     ▼                  ▼
 ///
 /// Components:
-/// - tx_cons: Sender half - used by dispatcher to push messages
-/// - rx_cons: Receiver half - used by gRPC handler to pull messages
+/// - stream_sender: Direct gRPC response sender (no intermediate task or double buffer)
 /// - session: Tracks connection state (active, cancellation, session_id)
-/// - reliable dispatch blocks on a full internal channel; non-reliable dispatch can drop/skip on full
+/// - reliable dispatch blocks on full gRPC stream buffer; non-reliable drops or skips on full
 /// ```
 ///
 /// # Lock Separation Strategy
 ///
-/// To avoid deadlock, we use separate locks for different access patterns:
+/// In Direct Channel Delivery, message dispatch and stream lifecycle are decoupled across three tiers to eliminate lock contention and avoid deadlocks:
 ///
 /// ```text
 /// ┌─────────────────────────────────────────────────────────────────────────┐
-/// │                          LOCK OWNERSHIP                                  │
+/// │                          LOCK SEPARATION TIERS                          │
 /// └─────────────────────────────────────────────────────────────────────────┘
 ///
-///  Dispatcher Thread              │              gRPC Stream Thread
-///                                 │
-///  1. Check if consumer active    │              1. Lock rx_cons (hold forever)
-///     session.lock().await        │                 rx_cons.lock().await
-///     ↓                           │                 ↓
-///  2. Read session.active         │              2. Loop: receive messages
-///     (quick unlock)              │                 loop { rx.recv().await }
-///     ↓                           │                 ↓
-///  3. Send message                │              3. Forward to client
-///     send_message().await        │                 grpc_tx.send().await
-///     or try_send_message()       │
-///                                 │
-///  ✓ No deadlock: different locks │
+///  Tier 1: Atomic Health Check (Hot Path)
+///  - Dispatcher checks `consumer.active` via `AtomicBool::load(Ordering::Acquire)`.
+///  - Cost: ~1ns, completely lock-free, zero contention. Inactive consumers are skipped.
+///
+///  Tier 2: Stream Sender Access (Hot Path)
+///  - Dispatcher reads `consumer.stream_sender` via `RwLock::read()`.
+///  - Clones `StreamSender` (~10ns atomic reference bump) and DROPS the guard immediately.
+///  - `sender.send().await` executes with NO locks held across the async boundary.
+///
+///  Tier 3: Lifecycle Session Management (Cold Path)
+///  - Used only on connect, disconnect, or takeover (`attach_stream`, `detach_stream`).
+///  - Held briefly in `ConsumerSession` mutex while updating session IDs and cancellation tokens.
+///  - Never contested by message dispatching.
 /// ```
 ///
-/// # Takeover Mechanism
+/// # Takeover Mechanism (Single-Attach Semantics)
 ///
-/// When a consumer reconnects with the same name (single-attach):
+/// When a consumer reconnects with the same name, Danube enforces single-attach semantics:
 ///
 /// ```text
 /// ┌─────────────────────────────────────────────────────────────────────────┐
 /// │                          TAKEOVER FLOW                                   │
 /// └─────────────────────────────────────────────────────────────────────────┘
 ///
-///  Old Connection                New Connection (same consumer_name)
-///       │                               │
-///       │  Streaming messages           │  1. subscribe() called
-///       │  via rx_cons                  │     ↓
-///       │                               │  2. session.cancel_stream()
-///       │  ◄─────────────────────────────────┘  cancels old task
-///       │  (cancellation.cancel())      │
-///       │                               │  3. session.takeover()
-///       │  Task exits                   │     - new session_id
-///       │  (cancelled)                  │     - new cancellation token
-///       │                               │     - set active=true
-///       ▼                               │
-///    Closed                             │  4. receive_messages() starts
-///                                       │     new streaming task
-///                                       │     ↓
-///                                       │  Streaming messages
-///                                       ▼  via same rx_cons
+///  Old Connection                 New Connection (same consumer_name)
+///       │                                │
+///       │  Streaming messages            │  1. subscribe() called
+///       │  via direct grpc_tx            │     ↓
+///       │                                │  2. consumer.cancel_stream()
+///       │  ◄────────────────────────────────── cancels old session token
+///       │  (cancellation.cancel())       │
+///       │                                │  3. receive_messages() called
+///       │                                │     ↓
+///       │                                │  4. consumer.attach_stream(new_grpc_tx)
+///       │                                │     - generates new session_id (e.g. S2)
+///       │                                │     - installs new_grpc_tx in stream_sender
+///       │                                │     - sets active = true
+///       │                                │     - wakes dispatcher for redelivery
+///       │  Watcher exits cleanly         │     ↓
+///       │  (detects cancelled token,     │  5. Dispatcher streams directly
+///       │   does NOT mark inactive)      ▼     to new_grpc_tx
+///       ▼
+///    Closed
+///       │
+///       │  If old TCP drops later:
+///       └───▶ detach_stream_if_session(S1)
+///             (Ignored! S1 != S2, new session remains active)
 /// ```
 ///
 #[allow(dead_code)]
@@ -118,6 +120,7 @@ pub(crate) struct Consumer {
     /// - 0: Exclusive (one consumer per subscription)
     /// - 1: Shared (round-robin distribution)
     /// - 2: Failover (active + standby consumers)
+    /// - 3: KeyShared (key-based distribution)
     pub(crate) subscription_type: i32,
 
     /// Full topic name this consumer is subscribed to.
@@ -128,50 +131,18 @@ pub(crate) struct Consumer {
     /// Multiple consumers can share the same subscription (except Exclusive).
     pub(crate) subscription_name: String,
 
-    /// **Message sender (Producer end of the internal channel)**.
-    ///
-    /// Used by: Dispatcher
-    /// - Reliable dispatchers call `consumer.send_message(msg)` which uses this sender
-    /// - Non-reliable dispatchers call `consumer.try_send_message(msg)` which uses this sender
-    /// - Pushes messages into the internal channel (buffer size: 4)
-    /// - Reliable sends block on full channel (backpressure)
-    /// - Non-reliable sends do not wait on full channel; callers can drop or skip the message
-    ///
-    /// Flow: `Dispatcher → tx_cons.send()/try_send() → Channel → rx_cons.recv() → gRPC`
-    pub(crate) tx_cons: mpsc::Sender<StreamMessage>,
-
-    /// **Session state: active status, cancellation token, session ID**.
-    ///
-    /// Used by: Both Dispatcher and gRPC handler
-    /// - Dispatcher: Checks `session.active` to see if consumer is healthy
-    /// - gRPC handler: Updates `session.active` on connect/disconnect
-    /// - Takeover: `session.takeover()` cancels old task and creates new session
-    ///
-    /// Locked separately from `rx_cons` to avoid deadlock:
-    /// - Dispatcher needs quick status checks (brief lock)
-    /// - gRPC handler holds `rx_cons` lock for entire stream duration
+    /// Session state: active status, cancellation token, session ID.
     pub(crate) session: Arc<Mutex<ConsumerSession>>,
 
+    /// Fast atomic flag for active status (checked lock-free by dispatchers).
     pub(crate) active: Arc<AtomicBool>,
 
-    /// **Message receiver (Consumer end of the internal channel)**.
-    ///
-    /// Used by: gRPC streaming task (consumer_handler.rs)
-    /// - Locked once at the start of `receive_messages()`
-    /// - Held for the entire duration of the streaming connection
-    /// - Continuously calls `rx_cons.recv()` to pull messages from channel
-    /// - Forwards received messages to client via `grpc_tx.send()`
-    ///
-    /// Flow: `Channel → rx_cons.recv() → gRPC → Client`
-    ///
-    /// **Why separate lock from `session`?**
-    /// - gRPC task holds this lock forever (while streaming)
-    /// - Dispatcher needs to check `session.active` frequently
-    /// - If both were in same lock → deadlock (gRPC holds, dispatcher waits)
-    pub(crate) rx_cons: Arc<Mutex<mpsc::Receiver<StreamMessage>>>,
+    /// Direct gRPC response stream sender.
+    /// Protected by RwLock for thread-safe stream attachment and detachment.
+    pub(crate) stream_sender: Arc<RwLock<Option<StreamSender>>>,
 }
 
-/// Result of a non-blocking send attempt to the consumer's internal channel.
+/// Result of a non-blocking send attempt to the consumer's channel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ConsumerSendStatus {
     Sent,
@@ -186,9 +157,7 @@ impl Consumer {
         subscription_type: i32,
         topic_name: &str,
         subscription_name: &str,
-        tx_cons: mpsc::Sender<StreamMessage>,
         session: Arc<Mutex<ConsumerSession>>,
-        rx_cons: Arc<Mutex<mpsc::Receiver<StreamMessage>>>,
     ) -> Self {
         let active = session
             .try_lock()
@@ -197,28 +166,115 @@ impl Consumer {
             .clone();
 
         Consumer {
-            consumer_id: consumer_id.into(),
+            consumer_id,
             consumer_name: consumer_name.into(),
             subscription_type,
             topic_name: topic_name.into(),
             subscription_name: subscription_name.into(),
-            tx_cons,
             session,
             active,
-            rx_cons,
+            stream_sender: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Convenience constructor with an already-attached gRPC stream (useful in tests).
+    #[cfg(test)]
+    pub(crate) fn new_with_stream(
+        consumer_id: u64,
+        consumer_name: &str,
+        subscription_type: i32,
+        topic_name: &str,
+        subscription_name: &str,
+        sender: StreamSender,
+    ) -> Self {
+        let session = Arc::new(Mutex::new(ConsumerSession::new()));
+        let consumer = Self::new(
+            consumer_id,
+            consumer_name,
+            subscription_type,
+            topic_name,
+            subscription_name,
+            session,
+        );
+        consumer.active.store(true, Ordering::Release);
+        *consumer.stream_sender.write().unwrap() = Some(sender);
+        consumer
+    }
+
+    /// Attach a new gRPC response streaming channel to this consumer.
+    ///
+    /// Cancels any previous session, assigns a new session ID and cancellation token,
+    /// installs the sender, and marks the consumer active.
+    pub(crate) async fn attach_stream(&self, sender: StreamSender) -> (CancellationToken, u64) {
+        let (token, session_id) = {
+            let mut session = self.session.lock().await;
+            let token = session.takeover();
+            (token, session.session_id)
+        };
+
+        {
+            let mut guard = self.stream_sender.write().unwrap();
+            *guard = Some(sender);
+        }
+
+        self.set_status_active().await;
+
+        debug!(
+            consumer_id = %self.consumer_id,
+            session_id = %session_id,
+            "consumer stream attached directly"
+        );
+
+        (token, session_id)
+    }
+
+    /// Detach the gRPC response streaming channel if the disconnecting session matches.
+    ///
+    /// This guard ensures an old disconnected session does not clobber a newly attached session.
+    pub(crate) async fn detach_stream_if_session(&self, session_id: u64) {
+        let session = self.session.lock().await;
+        if session.session_id == session_id {
+            self.active.store(false, Ordering::Release);
+            let mut guard = self.stream_sender.write().unwrap();
+            *guard = None;
+            debug!(
+                consumer_id = %self.consumer_id,
+                session_id = %session_id,
+                "consumer stream detached"
+            );
+        }
+    }
+
+    /// Cancel the current streaming session without waiting.
+    pub(crate) async fn cancel_stream(&self) {
+        let session = self.session.lock().await;
+        session.cancel_stream();
     }
 
     /// Blocking send path used by reliable dispatchers.
     ///
-    /// This method awaits channel capacity and returns an error if the consumer
-    /// channel has been closed.
+    /// Directly streams message into the gRPC response channel.
+    /// Awaits channel capacity and returns an error if the consumer channel is closed.
     pub(crate) async fn send_message(&mut self, message: StreamMessage) -> Result<()> {
-        // Since u8 is exactly 1 byte, the size in bytes will be equal to the number of elements in the vector.
         let payload_size = message.payload.len();
-        // Send the message to the other channel
-        if let Err(err) = self.tx_cons.send(message).await {
-            // Log the error and handle the channel closure scenario
+
+        let sender = {
+            let guard = self.stream_sender.read().unwrap();
+            guard.clone()
+        };
+
+        let sender = match sender {
+            Some(s) => s,
+            None => {
+                self.set_status_inactive().await;
+                return Err(anyhow!("failed to send message to consumer: stream not attached"));
+            }
+        };
+
+        let proto_message: ProtoStreamMessage = message.into();
+
+        if let Err(err) = sender.send(Ok(proto_message)).await {
+            self.set_status_inactive().await;
             warn!(
                 consumer_id = %self.consumer_id,
                 subscription = %self.subscription_name,
@@ -228,27 +284,41 @@ impl Consumer {
             );
             return Err(anyhow!("failed to send message to consumer: {}", err));
         } else {
-            trace!(consumer_id = %self.consumer_id, "sending the message over channel to consumer");
+            trace!(consumer_id = %self.consumer_id, "sending message directly to gRPC stream");
             counter!(CONSUMER_MESSAGES_OUT_TOTAL.name, "topic"=> self.topic_name.clone() , "subscription" => self.subscription_name.clone()).increment(1);
             counter!(CONSUMER_BYTES_OUT_TOTAL.name, "topic"=> self.topic_name.clone() , "subscription" => self.subscription_name.clone()).increment(payload_size as u64);
         }
 
-        // info!("Consumer task ended for consumer_id: {}", self.consumer_id);
         Ok(())
     }
 
     /// Non-blocking send path used by non-reliable dispatchers.
     ///
-    /// This method never awaits channel capacity:
+    /// Directly attempts to enqueue into the gRPC response channel:
     /// - `Sent`: message was enqueued
     /// - `Full`: channel is saturated; caller can drop or try another consumer
-    /// - `Closed`: receiver is gone; caller should treat the consumer as unavailable
+    /// - `Closed`: receiver is gone; marks consumer inactive
     pub(crate) fn try_send_message(&mut self, message: StreamMessage) -> ConsumerSendStatus {
         let payload_size = message.payload.len();
 
-        match self.tx_cons.try_send(message) {
+        let sender = {
+            let guard = self.stream_sender.read().unwrap();
+            guard.clone()
+        };
+
+        let sender = match sender {
+            Some(s) => s,
+            None => {
+                self.active.store(false, Ordering::Release);
+                return ConsumerSendStatus::Closed;
+            }
+        };
+
+        let proto_message: ProtoStreamMessage = message.into();
+
+        match sender.try_send(Ok(proto_message)) {
             Ok(()) => {
-                trace!(consumer_id = %self.consumer_id, "sending the message over channel to consumer");
+                trace!(consumer_id = %self.consumer_id, "sending message directly to gRPC stream");
                 counter!(CONSUMER_MESSAGES_OUT_TOTAL.name, "topic"=> self.topic_name.clone() , "subscription" => self.subscription_name.clone()).increment(1);
                 counter!(CONSUMER_BYTES_OUT_TOTAL.name, "topic"=> self.topic_name.clone() , "subscription" => self.subscription_name.clone()).increment(payload_size as u64);
                 ConsumerSendStatus::Sent
@@ -263,11 +333,12 @@ impl Consumer {
                 ConsumerSendStatus::Full
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.active.store(false, Ordering::Release);
                 warn!(
                     consumer_id = %self.consumer_id,
                     subscription = %self.subscription_name,
                     topic = %self.topic_name,
-                    "failed to send message to consumer"
+                    "failed to send message to consumer: channel closed"
                 );
                 ConsumerSendStatus::Closed
             }
@@ -284,9 +355,11 @@ impl Consumer {
         self.active.store(true, Ordering::Release);
     }
 
-    /// Set the consumer status to inactive
+    /// Set the consumer status to inactive and detach sender
     pub(crate) async fn set_status_inactive(&self) {
         self.active.store(false, Ordering::Release);
+        let mut guard = self.stream_sender.write().unwrap();
+        *guard = None;
     }
 }
 
@@ -296,66 +369,34 @@ impl Consumer {
 ///
 /// Tracks the lifecycle of a single consumer connection session. When a consumer
 /// reconnects (takeover), a new session is created with a new `session_id` and
-/// `cancellation` token, but the same `Consumer` struct is reused.
+/// `cancellation` token, but the same `Consumer` struct identity is retained.
 ///
-/// # Why Separate from Consumer?
+/// # Disconnect Race Protection
 ///
-/// Session state changes frequently (on connect/disconnect/takeover) while the
-/// consumer identity (consumer_id, topic_name, etc.) remains constant.
-///
-/// # Lock Contention Strategy
-///
-/// This struct is kept separate from `rx_cons` to avoid deadlock:
-/// - **Dispatcher**: Needs quick, frequent access to `active` status
-/// - **gRPC handler**: Holds `rx_cons` lock for entire streaming duration
-///
-/// If both were in the same lock, the dispatcher would block forever waiting
-/// for the gRPC task to release the lock (which it never does while streaming).
+/// Each connection holds a unique `session_id`. When an idle client disconnects or a channel
+/// closes, `detach_stream_if_session(session_id)` checks if the disconnecting session matches
+/// the current active session. If a takeover has already occurred and installed a newer session,
+/// the late disconnect signal from the old session is safely ignored.
 ///
 /// # Fields
-///
 #[derive(Debug)]
 pub(crate) struct ConsumerSession {
     /// Unique ID for this session (changes on reconnect/takeover).
-    ///
-    /// Each time a consumer reconnects, `takeover()` generates a new session_id.
-    /// This helps track and debug connection lifecycle in logs.
     pub(crate) session_id: u64,
 
     /// Whether this consumer is currently active and able to receive messages.
-    ///
-    /// **State transitions**:
-    /// - `true`: Consumer is connected and streaming messages
-    /// - `false`: Consumer disconnected or inactive
-    ///
-    /// **Updated by**:
-    /// - `new()`: Sets to `true` (new consumer starts active)
-    /// - `takeover()`: Sets to `true` (reconnection activates consumer)
-    /// - `set_status_inactive()`: Sets to `false` (on disconnect)
-    ///
-    /// **Read by**:
-    /// - Dispatcher: Checks before sending messages (skip inactive consumers)
     pub(crate) active: Arc<AtomicBool>,
 
-    /// Cancellation token for the gRPC streaming task.
-    ///
-    /// **Purpose**: Signals the streaming task to stop when:
-    /// - Consumer disconnects (normal shutdown)
-    /// - New connection arrives (takeover - cancel old task)
-    ///
-    /// **Lifecycle**:
-    /// - Created fresh on each `new()` or `takeover()`
-    /// - Cancelled via `cancel_stream()` or `takeover()`
-    /// - Streaming task monitors via `token.cancelled().await`
+    /// Cancellation token for the gRPC streaming connection.
     pub(crate) cancellation: CancellationToken,
 }
 
 impl ConsumerSession {
-    /// Create a new session
+    /// Create a new session (starts inactive until stream attached)
     pub(crate) fn new() -> Self {
         Self {
             session_id: get_random_id(),
-            active: Arc::new(AtomicBool::new(true)),
+            active: Arc::new(AtomicBool::new(false)),
             cancellation: CancellationToken::new(),
         }
     }
@@ -363,10 +404,8 @@ impl ConsumerSession {
     /// Takeover: cancel the current session and start a new one.
     /// Returns the new cancellation token for the streaming task.
     pub(crate) fn takeover(&mut self) -> CancellationToken {
-        // Cancel the existing streaming task
         self.cancellation.cancel();
 
-        // Create new session
         self.session_id = get_random_id();
         self.active.store(true, Ordering::Release);
         self.cancellation = CancellationToken::new();
@@ -393,3 +432,234 @@ impl ConsumerSession {
         self.cancellation.cancel();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use danube_core::message::MessageID;
+
+    fn make_test_msg(request_id: u64) -> StreamMessage {
+        StreamMessage {
+            request_id,
+            msg_id: MessageID {
+                producer_id: 1,
+                topic_name: "/default/test".to_string(),
+                broker_addr: "127.0.0.1:6650".to_string(),
+                topic_offset: request_id,
+            },
+            payload: "hello".as_bytes().to_vec().into(),
+            publish_time: 0,
+            producer_name: "prod".to_string(),
+            subscription_name: Some("sub".to_string()),
+            attributes: Default::default(),
+            schema_id: None,
+            schema_version: None,
+            routing_key: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_direct_delivery_lifecycle() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let mut consumer = Consumer::new_with_stream(
+            1,
+            "cons-1",
+            0,
+            "/default/test",
+            "sub",
+            tx,
+        );
+
+        assert!(consumer.get_status().await);
+
+        let msg = make_test_msg(100);
+        consumer.send_message(msg).await.expect("send succeeds");
+
+        let proto_msg = rx.recv().await.expect("recv").expect("ok");
+        assert_eq!(proto_msg.request_id, 100);
+    }
+
+    #[tokio::test]
+    async fn test_direct_delivery_when_unattached() {
+        let session = Arc::new(Mutex::new(ConsumerSession::new()));
+        let mut consumer = Consumer::new(
+            1,
+            "cons-1",
+            0,
+            "/default/test",
+            "sub",
+            session,
+        );
+
+        assert!(!consumer.get_status().await);
+
+        let msg = make_test_msg(101);
+        let err = consumer.send_message(msg).await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_attach_and_detach_session() {
+        let session = Arc::new(Mutex::new(ConsumerSession::new()));
+        let consumer = Consumer::new(
+            1,
+            "cons-1",
+            0,
+            "/default/test",
+            "sub",
+            session,
+        );
+
+        let (tx, _rx) = mpsc::channel(4);
+        let (_token, session_id) = consumer.attach_stream(tx).await;
+        assert!(consumer.get_status().await);
+
+        // Detach with wrong session ID should NOT detach
+        consumer.detach_stream_if_session(session_id + 999).await;
+        assert!(consumer.get_status().await);
+
+        // Detach with correct session ID should detach
+        consumer.detach_stream_if_session(session_id).await;
+        assert!(!consumer.get_status().await);
+    }
+
+    #[tokio::test]
+    async fn test_try_send_message_status_transitions() {
+        let (tx, mut rx) = mpsc::channel(2);
+        let mut consumer = Consumer::new_with_stream(
+            1,
+            "cons-1",
+            0,
+            "/default/test",
+            "sub",
+            tx,
+        );
+
+        assert_eq!(
+            consumer.try_send_message(make_test_msg(1)),
+            ConsumerSendStatus::Sent
+        );
+        assert_eq!(
+            consumer.try_send_message(make_test_msg(2)),
+            ConsumerSendStatus::Sent
+        );
+
+        // Channel capacity is 2; next try_send must report Full
+        assert_eq!(
+            consumer.try_send_message(make_test_msg(3)),
+            ConsumerSendStatus::Full
+        );
+        assert!(consumer.get_status().await);
+
+        // Drain messages
+        let _ = rx.recv().await;
+        let _ = rx.recv().await;
+
+        // Drop receiver -> channel is closed
+        drop(rx);
+
+        assert_eq!(
+            consumer.try_send_message(make_test_msg(4)),
+            ConsumerSendStatus::Closed
+        );
+        assert!(!consumer.get_status().await);
+    }
+
+    #[tokio::test]
+    async fn test_send_message_closed_marks_inactive() {
+        let (tx, rx) = mpsc::channel(2);
+        let mut consumer = Consumer::new_with_stream(
+            1,
+            "cons-1",
+            0,
+            "/default/test",
+            "sub",
+            tx,
+        );
+
+        drop(rx); // Closed immediately
+
+        let err = consumer.send_message(make_test_msg(1)).await;
+        assert!(err.is_err());
+        assert!(!consumer.get_status().await);
+    }
+
+    #[tokio::test]
+    async fn test_takeover_supersedes_old_session() {
+        let session = Arc::new(Mutex::new(ConsumerSession::new()));
+        let consumer = Consumer::new(
+            1,
+            "cons-1",
+            0,
+            "/default/test",
+            "sub",
+            session,
+        );
+
+        let (tx1, _rx1) = mpsc::channel(4);
+        let (token1, session_id1) = consumer.attach_stream(tx1).await;
+        assert!(consumer.get_status().await);
+        assert!(!token1.is_cancelled());
+
+        // Second attach (takeover)
+        let (tx2, mut rx2) = mpsc::channel(4);
+        let (token2, session_id2) = consumer.attach_stream(tx2).await;
+        assert!(token1.is_cancelled(), "old session must be cancelled");
+        assert!(!token2.is_cancelled(), "new session must not be cancelled");
+        assert_ne!(session_id1, session_id2);
+
+        // Old session disconnect signal must be ignored
+        consumer.detach_stream_if_session(session_id1).await;
+        assert!(consumer.get_status().await, "new session must remain active");
+
+        // Dispatched message must go to the new stream
+        let mut cons_clone = consumer.clone();
+        cons_clone.send_message(make_test_msg(200)).await.unwrap();
+        let delivered = rx2.recv().await.unwrap().unwrap();
+        assert_eq!(delivered.request_id, 200);
+
+        // Current session disconnect detaches
+        consumer.detach_stream_if_session(session_id2).await;
+        assert!(!consumer.get_status().await);
+    }
+
+    #[tokio::test]
+    async fn test_idle_disconnect_watcher() {
+        let session = Arc::new(Mutex::new(ConsumerSession::new()));
+        let consumer = Consumer::new(
+            1,
+            "cons-1",
+            0,
+            "/default/test",
+            "sub",
+            session,
+        );
+
+        let (tx, rx) = mpsc::channel(4);
+        let (token, session_id) = consumer.attach_stream(tx.clone()).await;
+        assert!(consumer.get_status().await);
+
+        let cons_for_watcher = consumer.clone();
+        let watcher = tokio::spawn(async move {
+            tokio::select! {
+                biased;
+                _ = token.cancelled() => {}
+                _ = tx.closed() => {
+                    cons_for_watcher.detach_stream_if_session(session_id).await;
+                }
+            }
+        });
+
+        // Drop the receiver (simulates client disconnect on idle topic)
+        drop(rx);
+
+        // Watcher must detect closure and detach
+        tokio::time::timeout(std::time::Duration::from_millis(500), watcher)
+            .await
+            .expect("watcher finishes promptly")
+            .unwrap();
+
+        assert!(!consumer.get_status().await);
+    }
+}
+

--- a/danube-broker/src/dispatcher/exclusive_test.rs
+++ b/danube-broker/src/dispatcher/exclusive_test.rs
@@ -29,10 +29,10 @@ use danube_core::message::{MessageID, StreamMessage};
 use danube_core::storage::PersistentStorage;
 use danube_persistent_storage::wal::{Wal, WalConfig};
 use danube_persistent_storage::{WalStorage, TieredStorage};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::mpsc;
 use tokio::time::timeout;
 
-use crate::consumer::{Consumer, ConsumerSession};
+use crate::consumer::Consumer;
 use crate::dispatcher::subscription_engine::SubscriptionEngine;
 use crate::dispatcher::Dispatcher;
 use crate::message::AckMessage;
@@ -101,11 +101,8 @@ async fn reliable_single_ack_gating() {
     );
 
     // Consumer wiring: use a channel to capture dispatched messages
-    let (tx, mut rx) = mpsc::channel::<StreamMessage>(8);
-    let (_rx_cons_tx, rx_cons_rx) = mpsc::channel::<StreamMessage>(8);
-    let session = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc = Arc::new(Mutex::new(rx_cons_rx));
-    let consumer = Consumer::new(42, "c1", 0, topic, "sub", tx, session, rx_cons_arc);
+    let (tx, mut rx) = mpsc::channel(8);
+    let consumer = Consumer::new_with_stream(42, "c1", 0, topic, "sub", tx);
     dispatcher
         .add_consumer(consumer)
         .await
@@ -122,7 +119,8 @@ async fn reliable_single_ack_gating() {
     let first = timeout(Duration::from_secs(2), rx.recv())
         .await
         .expect("timely first")
-        .expect("some");
+        .expect("some")
+        .expect("ok");
     assert_eq!(first.request_id, 100);
 
     // No second message until ack is sent
@@ -132,7 +130,7 @@ async fn reliable_single_ack_gating() {
     // Ack the first; then the second should arrive
     let ack = AckMessage {
         request_id: first.request_id,
-        msg_id: first.msg_id.clone(),
+        msg_id: first.msg_id.unwrap().into(),
         subscription_name: "test-sub".to_string(),
     };
     dispatcher.ack_message(ack).await.expect("ack");
@@ -145,7 +143,8 @@ async fn reliable_single_ack_gating() {
     let second = timeout(Duration::from_secs(2), rx.recv())
         .await
         .expect("timely second")
-        .expect("some");
+        .expect("some")
+        .expect("ok");
     assert_eq!(second.request_id, 101);
 }
 
@@ -171,11 +170,8 @@ async fn non_reliable_single_immediate_dispatch() {
 
     // Consumer wiring
     let topic = "/default/exclusive_non_reliable";
-    let (tx2, mut rx2) = mpsc::channel::<StreamMessage>(8);
-    let (_rx_cons_tx2, rx_cons_rx2) = mpsc::channel::<StreamMessage>(8);
-    let session2 = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc2 = Arc::new(Mutex::new(rx_cons_rx2));
-    let consumer2 = Consumer::new(43, "c2", 0, topic, "sub", tx2, session2, rx_cons_arc2);
+    let (tx2, mut rx2) = mpsc::channel(8);
+    let consumer2 = Consumer::new_with_stream(43, "c2", 0, topic, "sub", tx2);
     dispatcher
         .add_consumer(consumer2)
         .await
@@ -191,7 +187,8 @@ async fn non_reliable_single_immediate_dispatch() {
     let got = timeout(Duration::from_secs(2), rx2.recv())
         .await
         .expect("timely recv")
-        .expect("some");
+        .expect("some")
+        .expect("ok");
     assert_eq!(got.request_id, 200);
 }
 
@@ -200,16 +197,14 @@ async fn non_reliable_single_full_channel_drops_without_blocking() {
     let dispatcher = Dispatcher::non_reliable_exclusive();
 
     let topic = "/default/exclusive_non_reliable_full";
-    let (tx, mut rx) = mpsc::channel::<StreamMessage>(1);
+    let (tx, mut rx) = mpsc::channel(1);
     let fill_tx = tx.clone();
-    let (_rx_cons_tx, rx_cons_rx) = mpsc::channel::<StreamMessage>(8);
-    let session = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc = Arc::new(Mutex::new(rx_cons_rx));
-    let consumer = Consumer::new(44, "c3", 0, topic, "sub", tx, session, rx_cons_arc);
+    let consumer = Consumer::new_with_stream(44, "c3", 0, topic, "sub", tx);
     dispatcher.add_consumer(consumer).await.expect("add consumer");
 
+    let proto_msg: danube_core::proto::StreamMessage = make_msg(300, 0, topic).into();
     fill_tx
-        .try_send(make_msg(300, 0, topic))
+        .try_send(Ok(proto_msg))
         .expect("fill consumer channel");
 
     timeout(
@@ -223,7 +218,8 @@ async fn non_reliable_single_full_channel_drops_without_blocking() {
     let first = timeout(Duration::from_secs(1), rx.recv())
         .await
         .expect("timely recv")
-        .expect("some");
+        .expect("some")
+        .expect("ok");
     assert_eq!(first.request_id, 300);
 
     let second = timeout(Duration::from_millis(50), rx.recv()).await;

--- a/danube-broker/src/dispatcher/key_shared/consumer_state.rs
+++ b/danube-broker/src/dispatcher/key_shared/consumer_state.rs
@@ -268,24 +268,20 @@ mod tests {
     #[test]
     fn consistent_hash_stable() {
         use std::sync::Arc;
-        use tokio::sync::{mpsc, Mutex};
+        use tokio::sync::Mutex;
 
         let mut state = KeySharedConsumerState::new();
 
         // Create 3 mock consumers
         for i in 0..3u64 {
-            let (tx, _rx) = mpsc::channel(4);
             let session = Arc::new(Mutex::new(crate::consumer::ConsumerSession::new()));
-            let rx_arc = Arc::new(Mutex::new(_rx));
             let consumer = crate::consumer::Consumer::new(
                 i + 100,
                 &format!("consumer-{}", i),
                 3, // KeyShared
                 "test-topic",
                 "test-sub",
-                tx,
                 session,
-                rx_arc,
             );
             state.add_consumer(consumer, Vec::new());
         }
@@ -305,21 +301,17 @@ mod tests {
     #[test]
     fn consistent_hash_minimal_remapping() {
         use std::sync::Arc;
-        use tokio::sync::{mpsc, Mutex};
+        use tokio::sync::Mutex;
 
         let make_consumer = |id: u64| -> Consumer {
-            let (tx, _rx) = mpsc::channel(4);
             let session = Arc::new(Mutex::new(crate::consumer::ConsumerSession::new()));
-            let rx_arc = Arc::new(Mutex::new(_rx));
             crate::consumer::Consumer::new(
                 id,
                 &format!("consumer-{}", id),
                 3,
                 "test-topic",
                 "test-sub",
-                tx,
                 session,
-                rx_arc,
             )
         };
 

--- a/danube-broker/src/dispatcher/shared_test.rs
+++ b/danube-broker/src/dispatcher/shared_test.rs
@@ -32,10 +32,10 @@ use danube_core::message::{MessageID, StreamMessage};
 use danube_core::storage::PersistentStorage;
 use danube_persistent_storage::wal::{Wal, WalConfig};
 use danube_persistent_storage::{WalStorage, TieredStorage};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::mpsc;
 use tokio::time::timeout;
 
-use crate::consumer::{Consumer, ConsumerSession};
+use crate::consumer::Consumer;
 use crate::dispatcher::subscription_engine::SubscriptionEngine;
 use crate::dispatcher::Dispatcher;
 use crate::message::AckMessage;
@@ -103,18 +103,12 @@ async fn reliable_multiple_round_robin_ack_gating() {
     );
 
     // Two consumers capture messages
-    let (tx1, mut rx1) = mpsc::channel::<StreamMessage>(8);
-    let (_rx_cons_tx1, rx_cons_rx1) = mpsc::channel::<StreamMessage>(8);
-    let session1 = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc1 = Arc::new(Mutex::new(rx_cons_rx1));
-    let c1 = Consumer::new(42, "c1", 1, topic, "sub", tx1, session1, rx_cons_arc1);
+    let (tx1, mut rx1) = mpsc::channel(8);
+    let c1 = Consumer::new_with_stream(42, "c1", 1, topic, "sub", tx1);
     dispatcher.add_consumer(c1).await.expect("add c1");
 
-    let (tx2, mut rx2) = mpsc::channel::<StreamMessage>(8);
-    let (_rx_cons_tx2, rx_cons_rx2) = mpsc::channel::<StreamMessage>(8);
-    let session2 = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc2 = Arc::new(Mutex::new(rx_cons_rx2));
-    let c2 = Consumer::new(43, "c2", 1, topic, "sub", tx2, session2, rx_cons_arc2);
+    let (tx2, mut rx2) = mpsc::channel(8);
+    let c2 = Consumer::new_with_stream(43, "c2", 1, topic, "sub", tx2);
     dispatcher.add_consumer(c2).await.expect("add c2");
 
     // Wait for reliable dispatcher readiness (stream initialized)
@@ -127,8 +121,8 @@ async fn reliable_multiple_round_robin_ack_gating() {
     // Expect first delivery to either c1 or c2
     let first_delivered = timeout(Duration::from_secs(2), async {
         tokio::select! {
-            Some(m) = rx1.recv() => Ok::<(u64, StreamMessage), ()>((1, m)),
-            Some(m) = rx2.recv() => Ok::<(u64, StreamMessage), ()>((2, m)),
+            Some(Ok(m)) = rx1.recv() => Ok::<(u64, danube_core::proto::StreamMessage), ()>((1, m)),
+            Some(Ok(m)) = rx2.recv() => Ok::<(u64, danube_core::proto::StreamMessage), ()>((2, m)),
         }
     })
     .await
@@ -139,7 +133,7 @@ async fn reliable_multiple_round_robin_ack_gating() {
     let (first_consumer_id, first_msg) = first_delivered;
     let ack = AckMessage {
         request_id: first_msg.request_id,
-        msg_id: first_msg.msg_id.clone(),
+        msg_id: first_msg.msg_id.unwrap().into(),
         subscription_name: "test-sub".to_string(),
     };
     dispatcher.ack_message(ack).await.expect("ack first");
@@ -150,8 +144,8 @@ async fn reliable_multiple_round_robin_ack_gating() {
 
     let second_delivered = timeout(Duration::from_secs(2), async {
         tokio::select! {
-            Some(m) = rx1.recv() => Ok::<(u64, StreamMessage), ()>((1, m)),
-            Some(m) = rx2.recv() => Ok::<(u64, StreamMessage), ()>((2, m)),
+            Some(Ok(m)) = rx1.recv() => Ok::<(u64, danube_core::proto::StreamMessage), ()>((1, m)),
+            Some(Ok(m)) = rx2.recv() => Ok::<(u64, danube_core::proto::StreamMessage), ()>((2, m)),
         }
     })
     .await
@@ -194,36 +188,12 @@ async fn non_reliable_multiple_round_robin() {
     let topic = "/default/shared_non_reliable";
 
     // Two consumers capture messages
-    let (tx_c1, mut rx_c1) = mpsc::channel::<StreamMessage>(16);
-    let (_rx_cons_tx_c1, rx_cons_rx_c1) = mpsc::channel::<StreamMessage>(8);
-    let session_c1 = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc_c1 = Arc::new(Mutex::new(rx_cons_rx_c1));
-    let c1 = Consumer::new(
-        101,
-        "c1",
-        1,
-        topic,
-        "sub",
-        tx_c1,
-        session_c1,
-        rx_cons_arc_c1,
-    );
+    let (tx_c1, mut rx_c1) = mpsc::channel(16);
+    let c1 = Consumer::new_with_stream(101, "c1", 1, topic, "sub", tx_c1);
     dispatcher.add_consumer(c1).await.expect("add c1");
 
-    let (tx_c2, mut rx_c2) = mpsc::channel::<StreamMessage>(16);
-    let (_rx_cons_tx_c2, rx_cons_rx_c2) = mpsc::channel::<StreamMessage>(8);
-    let session_c2 = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc_c2 = Arc::new(Mutex::new(rx_cons_rx_c2));
-    let c2 = Consumer::new(
-        102,
-        "c2",
-        1,
-        topic,
-        "sub",
-        tx_c2,
-        session_c2,
-        rx_cons_arc_c2,
-    );
+    let (tx_c2, mut rx_c2) = mpsc::channel(16);
+    let c2 = Consumer::new_with_stream(102, "c2", 1, topic, "sub", tx_c2);
     dispatcher.add_consumer(c2).await.expect("add c2");
 
     // Dispatch 4 messages -> expect alternating delivery
@@ -239,8 +209,8 @@ async fn non_reliable_multiple_round_robin() {
     for _ in 0..4 {
         let m = timeout(Duration::from_secs(2), async {
             tokio::select! {
-                Some(m) = rx_c1.recv() => Ok::<(u64, StreamMessage), ()>((1, m)),
-                Some(m) = rx_c2.recv() => Ok::<(u64, StreamMessage), ()>((2, m)),
+                Some(Ok(m)) = rx_c1.recv() => Ok::<(u64, danube_core::proto::StreamMessage), ()>((1, m)),
+                Some(Ok(m)) = rx_c2.recv() => Ok::<(u64, danube_core::proto::StreamMessage), ()>((2, m)),
             }
         })
         .await
@@ -262,41 +232,18 @@ async fn non_reliable_shared_skips_full_consumer() {
 
     let topic = "/default/shared_non_reliable_full";
 
-    let (tx_c1, mut rx_c1) = mpsc::channel::<StreamMessage>(1);
+    let (tx_c1, mut rx_c1) = mpsc::channel(1);
     let fill_tx_c1 = tx_c1.clone();
-    let (_rx_cons_tx_c1, rx_cons_rx_c1) = mpsc::channel::<StreamMessage>(8);
-    let session_c1 = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc_c1 = Arc::new(Mutex::new(rx_cons_rx_c1));
-    let c1 = Consumer::new(
-        103,
-        "c1-full",
-        1,
-        topic,
-        "sub",
-        tx_c1,
-        session_c1,
-        rx_cons_arc_c1,
-    );
+    let c1 = Consumer::new_with_stream(103, "c1-full", 1, topic, "sub", tx_c1);
     dispatcher.add_consumer(c1).await.expect("add c1");
 
-    let (tx_c2, mut rx_c2) = mpsc::channel::<StreamMessage>(1);
-    let (_rx_cons_tx_c2, rx_cons_rx_c2) = mpsc::channel::<StreamMessage>(8);
-    let session_c2 = Arc::new(Mutex::new(ConsumerSession::new()));
-    let rx_cons_arc_c2 = Arc::new(Mutex::new(rx_cons_rx_c2));
-    let c2 = Consumer::new(
-        104,
-        "c2-fast",
-        1,
-        topic,
-        "sub",
-        tx_c2,
-        session_c2,
-        rx_cons_arc_c2,
-    );
+    let (tx_c2, mut rx_c2) = mpsc::channel(1);
+    let c2 = Consumer::new_with_stream(104, "c2-fast", 1, topic, "sub", tx_c2);
     dispatcher.add_consumer(c2).await.expect("add c2");
 
+    let proto_msg: danube_core::proto::StreamMessage = make_msg(800, 0, topic).into();
     fill_tx_c1
-        .try_send(make_msg(800, 0, topic))
+        .try_send(Ok(proto_msg))
         .expect("fill first consumer");
 
     dispatcher
@@ -307,13 +254,15 @@ async fn non_reliable_shared_skips_full_consumer() {
     let delivered = timeout(Duration::from_secs(1), rx_c2.recv())
         .await
         .expect("timely recv")
-        .expect("some");
+        .expect("some")
+        .expect("ok");
     assert_eq!(delivered.request_id, 801);
 
     let first = timeout(Duration::from_secs(1), rx_c1.recv())
         .await
         .expect("timely recv")
-        .expect("some");
+        .expect("some")
+        .expect("ok");
     assert_eq!(first.request_id, 800);
 
     let second = timeout(Duration::from_millis(50), rx_c1.recv()).await;

--- a/danube-broker/src/subscription.rs
+++ b/danube-broker/src/subscription.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Ok, Result};
 use metrics::gauge;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc, time::Duration};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::Mutex;
 use tokio::time::Instant;
 use tracing::trace;
 
@@ -153,21 +153,15 @@ impl Subscription {
         topic_name: &str,
         options: SubscriptionOptions,
     ) -> Result<u64> {
-        //for communication with client consumer
-        let (tx_cons, rx_cons) = mpsc::channel(4);
-
         let consumer_id = get_random_id();
         let session = Arc::new(Mutex::new(ConsumerSession::new()));
-        let rx_cons_arc = Arc::new(Mutex::new(rx_cons));
         let consumer = Consumer::new(
             consumer_id,
             &options.consumer_name,
             options.subscription_type,
             topic_name,
             &self.subscription_name,
-            tx_cons,
-            session.clone(),
-            rx_cons_arc.clone(),
+            session,
         );
 
         let dispatcher = self.dispatcher.as_mut().unwrap();

--- a/danube-broker/src/topic_control.rs
+++ b/danube-broker/src/topic_control.rs
@@ -582,10 +582,7 @@ impl TopicManager {
 
     /// Returns true if the consumer is healthy according to its subscription state.
     pub(crate) async fn health_consumer(&self, consumer_id: u64) -> bool {
-        if let Some(consumer) = self.find_consumer_by_id(consumer_id).await {
-            return consumer.get_status().await;
-        }
-        false
+        self.find_consumer_by_id(consumer_id).await.is_some()
     }
 
     /// Returns the consumer_id if a consumer with the given name exists on the subscription.

--- a/danube-broker/src/topic_tests.rs
+++ b/danube-broker/src/topic_tests.rs
@@ -469,10 +469,15 @@ async fn non_reliable_topic_publish_does_not_stall_on_full_subscription() -> Any
         (slow, fast)
     };
 
+    let (slow_tx, mut slow_rx) = tokio::sync::mpsc::channel(4);
+    let (fast_tx, mut fast_rx) = tokio::sync::mpsc::channel(4);
+    slow_consumer.attach_stream(slow_tx.clone()).await;
+    fast_consumer.attach_stream(fast_tx).await;
+
     for i in 0..4u64 {
-        slow_consumer
-            .tx_cons
-            .try_send(make_msg(9000 + i, topic_name))
+        let proto_msg: danube_core::proto::StreamMessage = make_msg(9000 + i, topic_name).into();
+        slow_tx
+            .try_send(Ok(proto_msg))
             .expect("fill slow consumer channel");
     }
 
@@ -484,25 +489,26 @@ async fn non_reliable_topic_publish_does_not_stall_on_full_subscription() -> Any
     .expect("publish should not block")?;
 
     let fast_msg = {
-        let mut rx = fast_consumer.rx_cons.lock().await;
-        timeout(Duration::from_secs(1), rx.recv())
+        let res = timeout(Duration::from_secs(1), fast_rx.recv())
             .await
             .expect("timely fast recv")
             .expect("fast consumer message")
+            .expect("ok");
+        res
     };
     assert_eq!(fast_msg.request_id, 9001);
 
     {
-        let mut rx = slow_consumer.rx_cons.lock().await;
         for i in 0..4u64 {
-            let msg = timeout(Duration::from_secs(1), rx.recv())
+            let msg = timeout(Duration::from_secs(1), slow_rx.recv())
                 .await
                 .expect("timely slow recv")
-                .expect("slow filler message");
+                .expect("slow filler message")
+                .expect("ok");
             assert_eq!(msg.request_id, 9000 + i);
         }
 
-        let second = timeout(Duration::from_millis(50), rx.recv()).await;
+        let second = timeout(Duration::from_millis(50), slow_rx.recv()).await;
         assert!(second.is_err(), "slow consumer should not receive published message");
     }
 


### PR DESCRIPTION
…g (Phase 2.2)

- Eliminate intermediate forwarding task and secondary mpsc queue hops in consumer message pipeline
- Stream messages directly from dispatchers into Tonic gRPC response channel
- Implement 3-tier lock separation strategy (lock-free atomic health check, zero-lock async send, isolated session mutex)
- Add zero-CPU idle disconnect watcher task awaiting grpc_tx.closed() with biased cancellation checks
- Add session guards preventing stale disconnects from clobbering new sessions on single-attach takeover
- Update dispatcher test suites (exclusive, shared, key-shared, topic_tests) and add dedicated consumer lifecycle tests