### PR TITLE
perf: implement zero-copy serialization, pre-cached metrics, and cont…

### DIFF
--- a/danube-broker/src/consumer.rs
+++ b/danube-broker/src/consumer.rs
@@ -140,6 +140,10 @@ pub(crate) struct Consumer {
     /// Direct gRPC response stream sender.
     /// Protected by RwLock for thread-safe stream attachment and detachment.
     pub(crate) stream_sender: Arc<RwLock<Option<StreamSender>>>,
+
+    /// Pre-registered egress counters for zero-allocation hot path
+    messages_out_counter: metrics::Counter,
+    bytes_out_counter: metrics::Counter,
 }
 
 /// Result of a non-blocking send attempt to the consumer's channel.
@@ -165,6 +169,17 @@ impl Consumer {
             .active
             .clone();
 
+        let messages_out_counter = counter!(
+            CONSUMER_MESSAGES_OUT_TOTAL.name,
+            "topic" => topic_name.to_string(),
+            "subscription" => subscription_name.to_string()
+        );
+        let bytes_out_counter = counter!(
+            CONSUMER_BYTES_OUT_TOTAL.name,
+            "topic" => topic_name.to_string(),
+            "subscription" => subscription_name.to_string()
+        );
+
         Consumer {
             consumer_id,
             consumer_name: consumer_name.into(),
@@ -174,6 +189,8 @@ impl Consumer {
             session,
             active,
             stream_sender: Arc::new(RwLock::new(None)),
+            messages_out_counter,
+            bytes_out_counter,
         }
     }
 
@@ -285,8 +302,8 @@ impl Consumer {
             return Err(anyhow!("failed to send message to consumer: {}", err));
         } else {
             trace!(consumer_id = %self.consumer_id, "sending message directly to gRPC stream");
-            counter!(CONSUMER_MESSAGES_OUT_TOTAL.name, "topic"=> self.topic_name.clone() , "subscription" => self.subscription_name.clone()).increment(1);
-            counter!(CONSUMER_BYTES_OUT_TOTAL.name, "topic"=> self.topic_name.clone() , "subscription" => self.subscription_name.clone()).increment(payload_size as u64);
+            self.messages_out_counter.increment(1);
+            self.bytes_out_counter.increment(payload_size as u64);
         }
 
         Ok(())
@@ -319,8 +336,8 @@ impl Consumer {
         match sender.try_send(Ok(proto_message)) {
             Ok(()) => {
                 trace!(consumer_id = %self.consumer_id, "sending message directly to gRPC stream");
-                counter!(CONSUMER_MESSAGES_OUT_TOTAL.name, "topic"=> self.topic_name.clone() , "subscription" => self.subscription_name.clone()).increment(1);
-                counter!(CONSUMER_BYTES_OUT_TOTAL.name, "topic"=> self.topic_name.clone() , "subscription" => self.subscription_name.clone()).increment(payload_size as u64);
+                self.messages_out_counter.increment(1);
+                self.bytes_out_counter.increment(payload_size as u64);
                 ConsumerSendStatus::Sent
             }
             Err(mpsc::error::TrySendError::Full(_)) => {

--- a/danube-broker/src/rate_limiter.rs
+++ b/danube-broker/src/rate_limiter.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use tokio::sync::Mutex;
 
 /// Simple token-bucket rate limiter for messages/sec
@@ -31,11 +31,10 @@ impl RateLimiter {
         let mut guard = self.inner.lock().await;
         let now = Instant::now();
         let elapsed = now.duration_since(guard.last_refill);
-        if elapsed >= Duration::from_secs(1) {
-            // Refill proportionally to elapsed seconds, capped at bucket size
-            let secs = elapsed.as_secs_f64();
+        let secs = elapsed.as_secs_f64();
+        if secs > 0.0 {
             guard.tokens = (guard.tokens + (self.max_per_sec as f64) * secs)
-                .clamp(0.0, self.max_per_sec as f64);
+                .min(self.max_per_sec as f64);
             guard.last_refill = now;
         }
         if guard.tokens >= n as f64 {
@@ -58,6 +57,23 @@ mod tests {
         for _ in 0..5 {
             assert!(rl.try_acquire(1).await);
         }
+        assert!(!rl.try_acquire(1).await);
+    }
+
+    #[tokio::test]
+    async fn refills_fractionally() {
+        // 10 tokens per sec => 1 token every 100ms
+        let rl = RateLimiter::new(10);
+        for _ in 0..10 {
+            assert!(rl.try_acquire(1).await);
+        }
+        assert!(!rl.try_acquire(1).await);
+        // Wait ~350ms -> should replenish ~3.5 tokens, allowing acquire of 3 tokens
+        sleep(Duration::from_millis(350)).await;
+        assert!(rl.try_acquire(1).await);
+        assert!(rl.try_acquire(1).await);
+        assert!(rl.try_acquire(1).await);
+        // 4th acquire should fail
         assert!(!rl.try_acquire(1).await);
     }
 

--- a/danube-broker/src/topic.rs
+++ b/danube-broker/src/topic.rs
@@ -82,6 +82,9 @@ pub(crate) struct Topic {
     metrics_collector: Arc<MetricsCollector>,
     // cluster-wide default for max_unacked_messages (from dispatch config)
     default_max_unacked_messages: usize,
+    // Pre-registered ingress counters for zero-allocation hot path
+    messages_in_counter: metrics::Counter,
+    bytes_in_counter: metrics::Counter,
 }
 
 impl Topic {
@@ -101,6 +104,15 @@ impl Topic {
             ConfigDispatchStrategy::Reliable => DispatchStrategy::Reliable,
         };
 
+        let messages_in_counter = counter!(
+            TOPIC_MESSAGES_IN_TOTAL.name,
+            "topic" => topic_name.to_string()
+        );
+        let bytes_in_counter = counter!(
+            TOPIC_BYTES_IN_TOTAL.name,
+            "topic" => topic_name.to_string()
+        );
+
         Topic {
             topic_name: topic_name.into(),
             schema_context: TopicSchemaContext::new(resources_schema),
@@ -117,6 +129,8 @@ impl Topic {
             publish_rate_limiter: None,
             metrics_collector,
             default_max_unacked_messages,
+            messages_in_counter,
+            bytes_in_counter,
         }
     }
 
@@ -269,17 +283,9 @@ impl Topic {
             ));
         }
 
-        // Update ingress counters (topic only)
-        counter!(
-            TOPIC_MESSAGES_IN_TOTAL.name,
-            "topic"=> self.topic_name.clone()
-        )
-        .increment(1);
-        counter!(
-            TOPIC_BYTES_IN_TOTAL.name,
-            "topic"=> self.topic_name.clone()
-        )
-        .increment(stream_message.payload.len() as u64);
+        // Update ingress counters (topic only) - zero allocation fast path
+        self.messages_in_counter.increment(1);
+        self.bytes_in_counter.increment(stream_message.payload.len() as u64);
 
         // Update internal atomic counters for LoadReport (lock-free)
         self.messages_in.fetch_add(1, Ordering::Relaxed);

--- a/danube-core/build.rs
+++ b/danube-core/build.rs
@@ -6,6 +6,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let out_dir = Path::new("src/proto");
     tonic_prost_build::configure()
         .out_dir(out_dir)
+        .bytes(".danube.StreamMessage.payload")
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &[

--- a/danube-core/src/message.rs
+++ b/danube-core/src/message.rs
@@ -91,7 +91,7 @@ impl From<ProtoStreamMessage> for StreamMessage {
                 || panic!("Message ID cannot be None"),
                 |msg_id| msg_id.into(),
             ),
-            payload: proto_stream_msg.payload.into(),
+            payload: proto_stream_msg.payload,
             publish_time: proto_stream_msg.publish_time,
             producer_name: proto_stream_msg.producer_name,
             subscription_name: Some(proto_stream_msg.subscription_name),
@@ -119,7 +119,7 @@ impl From<StreamMessage> for ProtoStreamMessage {
         ProtoStreamMessage {
             request_id: stream_msg.request_id,
             msg_id: Some(stream_msg.msg_id.into()), // Convert MessageID into MsgId
-            payload: stream_msg.payload.to_vec(),
+            payload: stream_msg.payload,
             publish_time: stream_msg.publish_time,
             producer_name: stream_msg.producer_name,
             subscription_name: stream_msg.subscription_name.unwrap_or_default(),

--- a/danube-core/src/proto/danube.rs
+++ b/danube-core/src/proto/danube.rs
@@ -150,8 +150,8 @@ pub struct StreamMessage {
     #[prost(message, optional, tag = "2")]
     pub msg_id: ::core::option::Option<MsgId>,
     /// The actual payload of the message
-    #[prost(bytes = "vec", tag = "3")]
-    pub payload: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "3")]
+    pub payload: ::prost::bytes::Bytes,
     /// Timestamp for when the message was published
     #[prost(uint64, tag = "4")]
     pub publish_time: u64,

--- a/danube-schema/src/registry.rs
+++ b/danube-schema/src/registry.rs
@@ -61,6 +61,29 @@ impl SchemaRegistry {
         }
     }
 
+    async fn wait_for_local_metadata_compatibility_mode(
+        &self,
+        subject: &str,
+        expected_mode: CompatibilityMode,
+    ) -> Result<SchemaMetadata> {
+        let deadline = Instant::now() + Self::LOCAL_METADATA_SYNC_TIMEOUT;
+        loop {
+            if let Ok(metadata) = self.storage.get_metadata(subject).await {
+                if metadata.compatibility_mode == expected_mode {
+                    return Ok(metadata);
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "Timed out waiting for local schema metadata for subject '{}' to reach compatibility mode {:?}",
+                    subject,
+                    expected_mode
+                ));
+            }
+            sleep(Self::LOCAL_METADATA_SYNC_POLL_INTERVAL).await;
+        }
+    }
+
     /// Register a new schema or return existing schema ID if identical schema exists
     pub async fn register_schema(
         &self,
@@ -214,6 +237,7 @@ impl SchemaRegistry {
         let mut metadata = self.storage.get_metadata(subject).await?;
         metadata.set_compatibility_mode(mode);
         self.storage.update_metadata(&metadata).await?;
+        self.wait_for_local_metadata_compatibility_mode(subject, mode).await?;
         Ok(())
     }
 


### PR DESCRIPTION
…inuous rate limiting

- Zero-copy egress payload: configure tonic prost build with .bytes(".danube.StreamMessage.payload") to use bytes::Bytes directly, eliminating vector allocations on protobuf conversions
- Pre-cached metrics handles: cache metrics::Counter handles in Topic and Consumer to eliminate dynamic string allocations, formatting, and metric registry hash-lookups on hot message paths
- Continuous fractional token replenishment: update RateLimiter::try_acquire to replenish tokens continuously based on elapsed fractional seconds while maintaining tokio::sync::Mutex
- Raft schema metadata synchronization: add wait_for_local_metadata_compatibility_mode in danube-schema to ensure local state replication on compatibility mode updates