### PR TITLE
perf(raft): compact bincode log serialization and watcher fast-paths

### DIFF
--- a/.github/workflows/broker-failover-e2e.yml
+++ b/.github/workflows/broker-failover-e2e.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - 'danube-broker/**'
+      - 'danube-raft/**'
       - '.github/workflows/broker-failover-e2e.yml'
+  workflow_dispatch:
 
 jobs:
   build_and_test:

--- a/.github/workflows/broker-reliable-move-shared-fs-e2e.yml
+++ b/.github/workflows/broker-reliable-move-shared-fs-e2e.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'danube-broker/**'
+      - 'danube-persistent-storage/**'
       - 'config/for_tests/danube_broker_shared_fs.yml'
       - '.github/workflows/broker-reliable-move-shared-fs-e2e.yml'
   workflow_dispatch:

--- a/.github/workflows/broker-restart-e2e.yml
+++ b/.github/workflows/broker-restart-e2e.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'danube-broker/**'
       - 'danube-raft/**'
+      - 'danube-persistent-storage/**'
       - '.github/workflows/broker-restart-e2e.yml'
   workflow_dispatch:
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Run broker unit tests (bin)
         run: cargo test --bin danube-broker
 
-      - name: Run library unit tests
+      - name: Run library tests
         run: |
-          cargo test --lib -p danube-client
-          cargo test --lib -p danube-raft
-          cargo test --lib -p danube-schema
-          cargo test --lib -p danube-persistent-storage
+          cargo test -p danube-client
+          cargo test -p danube-raft
+          cargo test -p danube-schema
+          cargo test -p danube-persistent-storage
 
       - name: Run danube-iceberg tests
         run: cargo test -p danube-iceberg

--- a/danube-client/src/client.rs
+++ b/danube-client/src/client.rs
@@ -225,6 +225,9 @@ impl DanubeClientBuilder {
     /// # Examples
     ///
     /// ```rust,no_run
+    /// use danube_client::DanubeClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// // Read token from a file on each request
     /// let client = DanubeClient::builder()
     ///     .service_url("https://broker:6650")
@@ -236,6 +239,8 @@ impl DanubeClientBuilder {
     ///     })
     ///     .build()
     ///     .await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_token_supplier(mut self, supplier: impl Fn() -> String + Send + Sync + 'static) -> Self {
         self.connection_options.token_supplier = Some(Arc::new(supplier));

--- a/danube-client/src/schema_registry_client.rs
+++ b/danube-client/src/schema_registry_client.rs
@@ -235,6 +235,7 @@ impl SchemaRegistryClient {
 /// use danube_client::{DanubeClient, SchemaType};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let avro_schema_bytes = b"{}";
 /// let client = DanubeClient::builder()
 ///     .service_url("http://localhost:6650")
 ///     .build()

--- a/danube-raft/src/commands.rs
+++ b/danube-raft/src/commands.rs
@@ -12,12 +12,14 @@ pub enum RaftCommand {
     /// Standard KV put.
     Put {
         key: String,
+        #[serde(with = "json_value_serde")]
         value: serde_json::Value,
     },
 
     /// Put with TTL (replaces ETCD lease + put_with_lease).
     PutWithTTL {
         key: String,
+        #[serde(with = "json_value_serde")]
         value: serde_json::Value,
         ttl_ms: u64,
     },
@@ -34,7 +36,9 @@ pub enum RaftCommand {
     /// Compare-and-swap for atomic metadata transitions.
     CompareAndSwap {
         key: String,
+        #[serde(with = "opt_json_value_serde")]
         expected: Option<serde_json::Value>,
+        #[serde(with = "json_value_serde")]
         new_value: serde_json::Value,
         ttl_ms: Option<u64>,
     },
@@ -46,6 +50,7 @@ pub enum RaftCommand {
 /// Versioned value stored in the state machine.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct VersionedValue {
+    #[serde(with = "json_value_serde")]
     pub value: serde_json::Value,
     /// Per-key version (like ETCD's version field). Starts at 1, incremented on each put.
     pub version: i64,
@@ -55,6 +60,58 @@ pub struct VersionedValue {
     pub ttl_ms: Option<u64>,
     /// Creation timestamp (milliseconds since UNIX epoch).
     pub created_at_ms: u64,
+}
+
+mod json_value_serde {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use serde_json::Value;
+
+    pub fn serialize<S>(value: &Value, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = serde_json::to_string(value).map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(&s)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        serde_json::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+mod opt_json_value_serde {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use serde_json::Value;
+
+    pub fn serialize<S>(value: &Option<Value>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => {
+                let s = serde_json::to_string(v).map_err(serde::ser::Error::custom)?;
+                serializer.serialize_some(&s)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<String> = Option::deserialize(deserializer)?;
+        match opt {
+            Some(s) => serde_json::from_str(&s)
+                .map(Some)
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
 }
 
 /// Response returned after applying a command to the state machine.

--- a/danube-raft/src/log_store.rs
+++ b/danube-raft/src/log_store.rs
@@ -150,8 +150,9 @@ impl RaftLogReader<TypeConfig> for RedbLogStore {
             .map_err(|e| to_storage_err(e, "range query"))?;
         for item in iter {
             let (_key, val) = item.map_err(|e| to_storage_err(e, "iterate log"))?;
-            let entry: Entry<TypeConfig> = serde_json::from_slice(val.value())
-                .map_err(|e| to_storage_err(e, "deserialize entry"))?;
+            let (entry, _): (Entry<TypeConfig>, _) =
+                bincode::serde::decode_from_slice(val.value(), bincode::config::standard())
+                    .map_err(|e| to_storage_err(e, "deserialize entry"))?;
             entries.push(entry);
         }
         Ok(entries)
@@ -174,8 +175,9 @@ impl RaftLogStorage<TypeConfig> for RedbLogStore {
 
         let last_log_id = match table.last() {
             Ok(Some((_key, val))) => {
-                let entry: Entry<TypeConfig> = serde_json::from_slice(val.value())
-                    .map_err(|e| to_storage_err(e, "deserialize last entry"))?;
+                let (entry, _): (Entry<TypeConfig>, _) =
+                    bincode::serde::decode_from_slice(val.value(), bincode::config::standard())
+                        .map_err(|e| to_storage_err(e, "deserialize last entry"))?;
                 Some(entry.log_id)
             }
             _ => last_purged,
@@ -223,8 +225,8 @@ impl RaftLogStorage<TypeConfig> for RedbLogStore {
                 .open_table(LOG_TABLE)
                 .map_err(|e| to_storage_err(e, "open log table"))?;
             for entry in entries {
-                let bytes =
-                    serde_json::to_vec(&entry).map_err(|e| to_storage_err(e, "serialize entry"))?;
+                let bytes = bincode::serde::encode_to_vec(&entry, bincode::config::standard())
+                    .map_err(|e| to_storage_err(e, "serialize entry"))?;
                 table
                     .insert(entry.log_id.index, bytes.as_slice())
                     .map_err(|e| to_storage_err(e, "insert entry"))?;

--- a/danube-raft/src/node.rs
+++ b/danube-raft/src/node.rs
@@ -254,6 +254,16 @@ impl RaftNode {
         Ok(())
     }
 
+    /// Gracefully shut down the Raft node, stopping the gRPC transport and background workers.
+    pub async fn shutdown(&self) -> anyhow::Result<()> {
+        self._grpc_handle.abort();
+        self._ttl_handle.abort();
+        self._metrics_handle.abort();
+        let _ = self.raft.shutdown().await;
+        Ok(())
+    }
+
+
     /// Bootstrap the Raft cluster based on seed node configuration.
     ///
     /// - **Empty `seed_nodes`**: single-node auto-init (development mode).
@@ -487,6 +497,9 @@ impl RaftNode {
         LeadershipHandle::new(self.raft.clone(), self.node_id)
     }
 }
+
+
+
 
 /// Watches Raft metrics for leader and membership changes, logging one line
 /// per state transition instead of per-request. This gives clean lifecycle

--- a/danube-raft/src/state_machine.rs
+++ b/danube-raft/src/state_machine.rs
@@ -100,15 +100,17 @@ fn apply_command(d: &mut StateMachineData, cmd: RaftCommand) -> RaftResponse {
                     created_at_ms: now,
                 },
             );
-            notify_watchers(
-                &d.watchers,
-                WatchEvent::Put {
-                    key: key.into_bytes(),
-                    value: serde_json::to_vec(&value).unwrap_or_default(),
-                    mod_revision: Some(d.global_revision),
-                    version: Some(ver),
-                },
-            );
+            if !d.watchers.is_empty() {
+                notify_watchers(
+                    &d.watchers,
+                    WatchEvent::Put {
+                        key: key.into_bytes(),
+                        value: serde_json::to_vec(&value).unwrap_or_default(),
+                        mod_revision: Some(d.global_revision),
+                        version: Some(ver),
+                    },
+                );
+            }
             RaftResponse::Ok
         }
 
@@ -138,41 +140,24 @@ fn apply_command(d: &mut StateMachineData, cmd: RaftCommand) -> RaftResponse {
                 .entry(expires_at)
                 .or_default()
                 .push(key.clone());
-            notify_watchers(
-                &d.watchers,
-                WatchEvent::Put {
-                    key: key.into_bytes(),
-                    value: serde_json::to_vec(&value).unwrap_or_default(),
-                    mod_revision: Some(d.global_revision),
-                    version: Some(ver),
-                },
-            );
+            if !d.watchers.is_empty() {
+                notify_watchers(
+                    &d.watchers,
+                    WatchEvent::Put {
+                        key: key.into_bytes(),
+                        value: serde_json::to_vec(&value).unwrap_or_default(),
+                        mod_revision: Some(d.global_revision),
+                        version: Some(ver),
+                    },
+                );
+            }
             RaftResponse::Ok
         }
 
         RaftCommand::Delete { key } => {
             d.global_revision += 1;
             d.kv.remove(&key);
-            notify_watchers(
-                &d.watchers,
-                WatchEvent::Delete {
-                    key: key.into_bytes(),
-                    mod_revision: Some(d.global_revision),
-                    version: None,
-                },
-            );
-            RaftResponse::Ok
-        }
-
-        RaftCommand::DeletePrefix { prefix } => {
-            d.global_revision += 1;
-            let keys_to_delete: Vec<String> =
-                d.kv.range(prefix.clone()..)
-                    .take_while(|(k, _)| k.starts_with(&prefix))
-                    .map(|(k, _)| k.clone())
-                    .collect();
-            for key in keys_to_delete {
-                d.kv.remove(&key);
+            if !d.watchers.is_empty() {
                 notify_watchers(
                     &d.watchers,
                     WatchEvent::Delete {
@@ -185,6 +170,30 @@ fn apply_command(d: &mut StateMachineData, cmd: RaftCommand) -> RaftResponse {
             RaftResponse::Ok
         }
 
+        RaftCommand::DeletePrefix { prefix } => {
+            d.global_revision += 1;
+            let keys_to_delete: Vec<String> =
+                d.kv.range(prefix.clone()..)
+                    .take_while(|(k, _)| k.starts_with(&prefix))
+                    .map(|(k, _)| k.clone())
+                    .collect();
+            let has_watchers = !d.watchers.is_empty();
+            for key in keys_to_delete {
+                d.kv.remove(&key);
+                if has_watchers {
+                    notify_watchers(
+                        &d.watchers,
+                        WatchEvent::Delete {
+                            key: key.into_bytes(),
+                            mod_revision: Some(d.global_revision),
+                            version: None,
+                        },
+                    );
+                }
+            }
+            RaftResponse::Ok
+        }
+
         RaftCommand::ExpireTTLKeys { keys } => {
             d.global_revision += 1;
             let now = now_ms();
@@ -193,8 +202,9 @@ fn apply_command(d: &mut StateMachineData, cmd: RaftCommand) -> RaftResponse {
             for ts in expired_timestamps {
                 d.ttl_entries.remove(&ts);
             }
+            let has_watchers = !d.watchers.is_empty();
             for key in keys {
-                if d.kv.remove(&key).is_some() {
+                if d.kv.remove(&key).is_some() && has_watchers {
                     notify_watchers(
                         &d.watchers,
                         WatchEvent::Delete {
@@ -242,15 +252,17 @@ fn apply_command(d: &mut StateMachineData, cmd: RaftCommand) -> RaftResponse {
                         .or_default()
                         .push(key.clone());
                 }
-                notify_watchers(
-                    &d.watchers,
-                    WatchEvent::Put {
-                        key: key.into_bytes(),
-                        value: serde_json::to_vec(&new_value).unwrap_or_default(),
-                        mod_revision: Some(d.global_revision),
-                        version: Some(ver),
-                    },
-                );
+                if !d.watchers.is_empty() {
+                    notify_watchers(
+                        &d.watchers,
+                        WatchEvent::Put {
+                            key: key.into_bytes(),
+                            value: serde_json::to_vec(&new_value).unwrap_or_default(),
+                            mod_revision: Some(d.global_revision),
+                            version: Some(ver),
+                        },
+                    );
+                }
                 RaftResponse::Ok
             } else {
                 RaftResponse::CasFailed { current }
@@ -266,11 +278,13 @@ fn apply_command(d: &mut StateMachineData, cmd: RaftCommand) -> RaftResponse {
 }
 
 fn notify_watchers(watchers: &DashMap<String, broadcast::Sender<WatchEvent>>, event: WatchEvent) {
-    let key_str = match &event {
-        WatchEvent::Put { key, .. } | WatchEvent::Delete { key, .. } => {
-            String::from_utf8_lossy(key).to_string()
-        }
+    if watchers.is_empty() {
+        return;
+    }
+    let key_bytes = match &event {
+        WatchEvent::Put { key, .. } | WatchEvent::Delete { key, .. } => key.as_slice(),
     };
+    let key_str = String::from_utf8_lossy(key_bytes);
     for entry in watchers.iter() {
         if key_str.starts_with(entry.key()) {
             let _ = entry.value().send(event.clone());

--- a/danube-raft/tests/cluster_and_leadership.rs
+++ b/danube-raft/tests/cluster_and_leadership.rs
@@ -73,3 +73,158 @@ async fn leader_publishes_id_to_metadata_store() {
         .expect("leader key should exist");
     assert_eq!(val.as_u64(), Some(broker_id));
 }
+
+/// **What**: Verify that data persisted to the Redb log store survives a complete node
+/// restart, and that the restarted node recovers state machine data and re-establishes leadership.
+///
+/// **Why**: In production, brokers and Raft nodes restart for upgrades, maintenance,
+/// or crashes. Raft correctness depends on persisting log entries and metadata to redb,
+/// and replaying committed entries into the state machine on startup.
+///
+/// **Checks**:
+/// - Writes (`put`, `allocate_monotonic_id`) succeed on the initial node
+/// - The node is cleanly shut down
+/// - A new `RaftNode` started on the SAME data directory retains its stable `node_id`
+/// - `bootstrap_cluster` recognizes the persisted state (`BootstrapResult::Restart`)
+/// - The restarted node recovers previously written keys, values, and counters
+/// - New writes succeed on the restarted node
+#[tokio::test]
+async fn node_restart_recovers_state_from_redb_log() {
+    let tmp = tempfile::TempDir::new().expect("create temp dir");
+    let data_dir = tmp.path().to_path_buf();
+    let port1 = common::next_port();
+    let addr1: std::net::SocketAddr = format!("127.0.0.1:{}", port1).parse().unwrap();
+
+    // 1. Boot first node and initialize cluster
+    let node1 = danube_raft::node::RaftNode::start(danube_raft::node::RaftNodeConfig {
+        data_dir: data_dir.clone(),
+        raft_addr: addr1,
+        advertised_addr: None,
+        ttl_check_interval: std::time::Duration::from_millis(200),
+        tls: None,
+    })
+    .await
+    .expect("start first node");
+
+    let initial_node_id = node1.node_id;
+    node1
+        .init_cluster(&addr1.to_string())
+        .await
+        .expect("init cluster");
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // 2. Perform writes on the initial node
+    node1
+        .store
+        .put(
+            "/topics/orders",
+            serde_json::json!({"partitions": 4}),
+            MetaOptions::None,
+        )
+        .await
+        .unwrap();
+    node1
+        .store
+        .put(
+            "/topics/payments",
+            serde_json::json!({"partitions": 2}),
+            MetaOptions::None,
+        )
+        .await
+        .unwrap();
+
+    let id1 = node1.store.allocate_monotonic_id("schemas").await.unwrap();
+    assert_eq!(id1, 1);
+    let id2 = node1.store.allocate_monotonic_id("schemas").await.unwrap();
+    assert_eq!(id2, 2);
+
+    // 3. Shut down node1 cleanly
+    node1.shutdown().await.expect("shutdown node1");
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // 4. Start node2 on the SAME data_dir (simulating broker restart)
+    let port2 = common::next_port();
+    let addr2: std::net::SocketAddr = format!("127.0.0.1:{}", port2).parse().unwrap();
+
+    let node2 = danube_raft::node::RaftNode::start(danube_raft::node::RaftNodeConfig {
+        data_dir: data_dir.clone(),
+        raft_addr: addr2,
+        advertised_addr: None,
+        ttl_check_interval: std::time::Duration::from_millis(200),
+        tls: None,
+    })
+    .await
+    .expect("start restarted node");
+
+    // Must preserve identical stable node_id from {data_dir}/node_id
+    assert_eq!(
+        node2.node_id, initial_node_id,
+        "restarted node must preserve stable node_id"
+    );
+
+    // Bootstrap cluster should detect restart mode
+    let res = node2
+        .bootstrap_cluster(&addr2.to_string(), &[])
+        .await
+        .expect("bootstrap restarted node");
+    assert!(
+        matches!(res, danube_raft::BootstrapResult::Restart),
+        "should detect restart, got {:?}",
+        res
+    );
+
+    // Give state machine a moment to replay committed log entries
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // 5. Verify persisted data was restored
+    let val_orders = node2
+        .store
+        .get("/topics/orders", MetaOptions::None)
+        .await
+        .unwrap();
+    assert_eq!(
+        val_orders,
+        Some(serde_json::json!({"partitions": 4})),
+        "persisted orders topic should be restored"
+    );
+
+    let val_payments = node2
+        .store
+        .get("/topics/payments", MetaOptions::None)
+        .await
+        .unwrap();
+    assert_eq!(
+        val_payments,
+        Some(serde_json::json!({"partitions": 2})),
+        "persisted payments topic should be restored"
+    );
+
+    // Verify counter state continues from previously allocated IDs
+    let id3 = node2.store.allocate_monotonic_id("schemas").await.unwrap();
+    assert_eq!(id3, 3, "monotonic id counter should resume from 3");
+
+    // 6. Verify new writes succeed on restarted node
+    node2
+        .store
+        .put(
+            "/topics/shipments",
+            serde_json::json!({"partitions": 1}),
+            MetaOptions::None,
+        )
+        .await
+        .unwrap();
+
+    let val_shipments = node2
+        .store
+        .get("/topics/shipments", MetaOptions::None)
+        .await
+        .unwrap();
+    assert_eq!(
+        val_shipments,
+        Some(serde_json::json!({"partitions": 1}))
+    );
+
+    node2.shutdown().await.expect("shutdown node2");
+}
+

--- a/danube-raft/tests/common/mod.rs
+++ b/danube-raft/tests/common/mod.rs
@@ -14,7 +14,7 @@ use tempfile::TempDir;
 /// Global port counter so parallel tests don't collide.
 static PORT: AtomicU16 = AtomicU16::new(17650);
 
-fn next_port() -> u16 {
+pub fn next_port() -> u16 {
     PORT.fetch_add(1, Ordering::Relaxed)
 }
 

--- a/danube-raft/tests/metadata_store_crud.rs
+++ b/danube-raft/tests/metadata_store_crud.rs
@@ -268,3 +268,41 @@ async fn get_bulk_empty_prefix() {
     let bulk = store.get_bulk("/nothing/here/").await.unwrap();
     assert!(bulk.is_empty());
 }
+
+// ─── Atomic Monotonic Counters ─────────────────────────────────────────────
+
+/// **What**: Verify `allocate_monotonic_id` increments atomically and independently
+/// per counter key through Raft consensus.
+///
+/// **Why**: The schema registry uses `allocate_monotonic_id` to generate sequential
+/// schema IDs. Different schemas and resources rely on unique, monotonic sequences.
+///
+/// **Checks**:
+/// - First allocation on a key returns 1
+/// - Subsequent allocations increment monotonically (2, 3, 4)
+/// - A different counter key has its own independent sequence starting at 1
+#[tokio::test]
+async fn allocate_monotonic_id_increments_independently() {
+    let (node, _tmp) = common::start_cluster().await;
+    let store = &node.store;
+
+    let id1 = store.allocate_monotonic_id("schemas").await.unwrap();
+    assert_eq!(id1, 1);
+
+    let id2 = store.allocate_monotonic_id("schemas").await.unwrap();
+    assert_eq!(id2, 2);
+
+    let id3 = store.allocate_monotonic_id("schemas").await.unwrap();
+    assert_eq!(id3, 3);
+
+    // Independent counter key starts at 1
+    let other1 = store.allocate_monotonic_id("topics").await.unwrap();
+    assert_eq!(other1, 1);
+
+    let id4 = store.allocate_monotonic_id("schemas").await.unwrap();
+    assert_eq!(id4, 4);
+
+    let other2 = store.allocate_monotonic_id("topics").await.unwrap();
+    assert_eq!(other2, 2);
+}
+


### PR DESCRIPTION
- Replace human-readable JSON serialization with compact bincode binary encoding/decoding for RedbLogStore (append, try_get_log_entries, and get_log_state).
- Add custom serde handlers in commands.rs for serde_json::Value to allow bincode to serialize/deserialize RaftCommand and VersionedValue without AnyNotSupported errors.
- Short-circuit watcher notifications in state_machine.rs when no watchers are registered, avoiding WatchEvent allocations and JSON value re-serialization on write hot paths.
- Avoid heap allocation in notify_watchers by using borrowed Cow<'_, str> directly for prefix matching.
- Add RaftNode::shutdown(&self) to cleanly terminate gRPC and background tasks.
- Add test coverage for atomic counter allocation (allocate_monotonic_id) in metadata_store_crud.rs.
- Add integration test for node restart and persistence recovery from RedbLogStore in cluster_and_leadership.rs.